### PR TITLE
[COM-11786] Add markup for new variant select layout

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -12,7 +12,8 @@
         <option value="">{selectText|message variantName:name}</option>
         {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
-    </div>
+    </div>{.repeated section values}
+    <div class="variant-box" value="{@|htmltag}">{@|htmltag}</div>{.end}
     </div>{.end}
   </div>
 {.end}

--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -12,8 +12,11 @@
         <option value="">{selectText|message variantName:name}</option>
         {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
-    </div>{.repeated section values}
-    <div class="variant-box" value="{@|htmltag}">{@|htmltag}</div>{.end}
+    </div>
+    <div class="variant-radiobtn-wrapper">{.repeated section values}
+      <input type="radio" class="variant-radiobtn" value="{@|htmltag}" name="variant-option-{name}" id="variant-option-{name}-{@|htmltag}"/>
+      <label for="variant-option-{name}-{@|htmltag}">{@|htmltag}</label>{.end}
+    </div>
     </div>{.end}
   </div>
 {.end}

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -25,6 +25,8 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-box" value="blue">blue</div>
+    <div class="variant-box" value="red">red</div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -34,6 +36,8 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
+    <div class="variant-box" value="loose">loose</div>
+    <div class="variant-box" value="slim">slim</div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -25,8 +25,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-box" value="blue">blue</div>
-    <div class="variant-box" value="red">red</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -36,8 +40,12 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-box" value="loose">loose</div>
-    <div class="variant-box" value="slim">slim</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
+    </div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -25,6 +25,8 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-box" value="blue">blue</div>
+    <div class="variant-box" value="red">red</div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -34,6 +36,8 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
+    <div class="variant-box" value="loose">loose</div>
+    <div class="variant-box" value="slim">slim</div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -25,8 +25,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-box" value="blue">blue</div>
-    <div class="variant-box" value="red">red</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -36,8 +40,12 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-box" value="loose">loose</div>
-    <div class="variant-box" value="slim">slim</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
+    </div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -25,6 +25,8 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
+    <div class="variant-box" value="loose">loose</div>
+    <div class="variant-box" value="slim">slim</div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
@@ -34,6 +36,8 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-box" value="blue">blue</div>
+    <div class="variant-box" value="red">red</div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -25,8 +25,12 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-box" value="loose">loose</div>
-    <div class="variant-box" value="slim">slim</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
@@ -36,8 +40,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-box" value="blue">blue</div>
-    <div class="variant-box" value="red">red</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -32,8 +32,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-box" value="blue">blue</div>
-    <div class="variant-box" value="red">red</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -43,8 +47,12 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-box" value="loose">loose</div>
-    <div class="variant-box" value="slim">slim</div>
+    <div class="variant-radiobtn-wrapper">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
+    </div>
     </div>
   </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -32,6 +32,8 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-box" value="blue">blue</div>
+    <div class="variant-box" value="red">red</div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -41,6 +43,8 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
+    <div class="variant-box" value="loose">loose</div>
+    <div class="variant-box" value="slim">slim</div>
     </div>
   </div>
 


### PR DESCRIPTION
We are supporting a new design for the `variant-select` formatter that will replace the dropdowns with selectable boxes. Users will be able to switch between these with a site-level tweak so we need the markup for both.