### PR TITLE
Add data-variant-option-name attribute to radio button wrapper for parity

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -13,9 +13,9 @@
         {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">{.repeated section values}
-      <input type="radio" class="variant-radiobtn" value="{@|htmltag}" name="variant-option-{name}" id="variant-option-{name}-{@|htmltag}"/>
-      <label for="variant-option-{name}-{@|htmltag}">{@|htmltag}</label>{.end}
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="{name|htmltag}">{.repeated section values}
+      <input type="radio" class="variant-radiobtn" value="{@|htmltag}" name="variant-option-{name|htmltag}" id="variant-option-{name|htmltag}-{@|htmltag}"/>
+      <label for="variant-option-{name|htmltag}-{@|htmltag}">{@|htmltag}</label>{.end}
     </div>
     </div>{.end}
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -25,7 +25,7 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
       <label for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
@@ -40,7 +40,7 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
       <label for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -25,7 +25,7 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
       <label for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
@@ -40,7 +40,7 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
       <label for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -25,7 +25,7 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
       <label for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
@@ -40,7 +40,7 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
       <label for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -32,7 +32,7 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
       <label for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
@@ -47,7 +47,7 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
-    <div class="variant-radiobtn-wrapper">
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
       <label for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>


### PR DESCRIPTION
This PR adds the `data-variant-option-name` attribute to the `variant-radiobtn-wrapper` for parity with the preceding <select> elements. It also wraps all calls to name in htmltag formatters to escape any special characters e.g. <, >.