### PR TITLE
Add aria labels to variant select for accessibility

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -9,8 +9,8 @@
     <div class="variant-option-title">{name}: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="{name|htmltag}">
-        <option value="">{selectText|message variantName:name}</option>
-        {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
+        <option aria-label="{selectText|message variantName:name}" value="">{selectText|message variantName:name}</option>
+        {.repeated section values}<option aria-label="{@|htmltag}" value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
     </div>
     </div>{.end}

--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -8,9 +8,9 @@
     <div class="variant-option">
     <div class="variant-option-title">{name}: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="{name|htmltag}">
-        <option aria-label="{selectText|message variantName:name}" value="">{selectText|message variantName:name}</option>
-        {.repeated section values}<option aria-label="{@|htmltag}" value="{@|htmltag}">{@|htmltag}</option>{.end}
+      <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
+        <option value="">{selectText|message variantName:name}</option>
+        {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
     </div>
     </div>{.end}

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -21,8 +21,8 @@
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="color">
-        <option value="">Select color</option>
-        <option value="blue">blue</option><option value="red">red</option>
+        <option aria-label="Select color" value="">Select color</option>
+        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
       </select>
     </div>
     </div>
@@ -30,8 +30,8 @@
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="fit">
-        <option value="">Select fit</option>
-        <option value="loose">loose</option><option value="slim">slim</option>
+        <option aria-label="Select fit" value="">Select fit</option>
+        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -20,18 +20,18 @@
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="color">
-        <option aria-label="Select color" value="">Select color</option>
-        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
+      <select aria-label="Select color" data-variant-option-name="color">
+        <option value="">Select color</option>
+        <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="fit">
-        <option aria-label="Select fit" value="">Select fit</option>
-        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
+        <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -21,8 +21,8 @@
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="color">
-        <option value="">Select color</option>
-        <option value="blue">blue</option><option value="red">red</option>
+        <option aria-label="Select color" value="">Select color</option>
+        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
       </select>
     </div>
     </div>
@@ -30,8 +30,8 @@
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="fit">
-        <option value="">Select fit</option>
-        <option value="loose">loose</option><option value="slim">slim</option>
+        <option aria-label="Select fit" value="">Select fit</option>
+        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -20,18 +20,18 @@
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="color">
-        <option aria-label="Select color" value="">Select color</option>
-        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
+      <select aria-label="Select color" data-variant-option-name="color">
+        <option value="">Select color</option>
+        <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="fit">
-        <option aria-label="Select fit" value="">Select fit</option>
-        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
+        <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -21,8 +21,8 @@
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="fit">
-        <option value="">Select fit</option>
-        <option value="loose">loose</option><option value="slim">slim</option>
+        <option aria-label="Select fit" value="">Select fit</option>
+        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
       </select>
     </div>
     </div>
@@ -30,8 +30,8 @@
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="color">
-        <option value="">Select color</option>
-        <option value="blue">blue</option><option value="red">red</option>
+        <option aria-label="Select color" value="">Select color</option>
+        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -20,18 +20,18 @@
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="fit">
-        <option aria-label="Select fit" value="">Select fit</option>
-        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
+        <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="color">
-        <option aria-label="Select color" value="">Select color</option>
-        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
+      <select aria-label="Select color" data-variant-option-name="color">
+        <option value="">Select color</option>
+        <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -28,8 +28,8 @@
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="color">
-        <option value="">Select color</option>
-        <option value="blue">blue</option><option value="red">red</option>
+        <option aria-label="Select color" value="">Select color</option>
+        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
       </select>
     </div>
     </div>
@@ -37,8 +37,8 @@
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
       <select data-variant-option-name="fit">
-        <option value="">Select fit</option>
-        <option value="loose">loose</option><option value="slim">slim</option>
+        <option aria-label="Select fit" value="">Select fit</option>
+        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
       </select>
     </div>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -27,18 +27,18 @@
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="color">
-        <option aria-label="Select color" value="">Select color</option>
-        <option aria-label="blue" value="blue">blue</option><option aria-label="red" value="red">red</option>
+      <select aria-label="Select color" data-variant-option-name="color">
+        <option value="">Select color</option>
+        <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select data-variant-option-name="fit">
-        <option aria-label="Select fit" value="">Select fit</option>
-        <option aria-label="loose" value="loose">loose</option><option aria-label="slim" value="slim">slim</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
+        <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
     </div>


### PR DESCRIPTION
This PR adds an `aria-label` property to the select element to expose its purpose to screenreaders.