### PR TITLE
COM-10948: Add hidden span for screen reader to read out label for sale price/original price

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/product-price.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/product-price.html
@@ -1,5 +1,8 @@
+{.var @originalPriceText localizedStrings.originalPriceText}
+{.var @salePriceText localizedStrings.salePriceText}
+
 <div class="product-price">
 {.if formattedFromPrice}{fromText|message fromPrice:formattedFromPrice price:formattedFromPrice billingPeriodValue:billingPeriodValue duration:duration}
-{.or}{.if formattedSalePrice}{formattedSalePriceText|message price:formattedSalePrice billingPeriodValue:billingPeriodValue duration:duration}{.space}<span class="original-price">{formattedNormalPriceText|message price:formattedNormalPrice billingPeriodValue:billingPeriodValue duration:duration}</span>
+{.or}{.if formattedSalePrice}<span class="visually-hidden v6-visually-hidden">{.if @salePriceText}{@salePriceText|htmltag}{.or}Sale Price:{.end}</span>{formattedSalePriceText|message price:formattedSalePrice billingPeriodValue:billingPeriodValue duration:duration}{.space}<span class="visually-hidden v6-visually-hidden">{.if @originalPriceText}{@originalPriceText|htmltag}{.or}Original Price:{.end}</span><span class="original-price">{formattedNormalPriceText|message price:formattedNormalPrice billingPeriodValue:billingPeriodValue duration:duration}</span>
 {.or}{.if formattedNormalPrice}{formattedNormalPriceText|message price:formattedNormalPrice billingPeriodValue:billingPeriodValue duration:duration}{.end}{.end}{.end}
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-3.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-3.html
@@ -13,6 +13,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> <span class="original-price"><span class="sqs-money-native">100.00</span></span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">100.00</span></span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-6.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-6.html
@@ -13,6 +13,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">200.00</span> <span class="original-price"><span class="sqs-money-native">400.00</span></span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">200.00</span> <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">400.00</span></span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-bi-monthly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-bi-monthly.html
@@ -31,6 +31,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every 2 months for 14 months <span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months for 14 months</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 months for 14 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months for 14 months</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-bi-weekly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-bi-weekly.html
@@ -31,6 +31,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every 2 weeks for 12 weeks <span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks for 12 weeks</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 weeks for 12 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks for 12 weeks</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-monthly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-monthly.html
@@ -31,6 +31,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every month for 6 months <span class="original-price"><span class="sqs-money-native">200.00</span> every month for 6 months</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every month for 6 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every month for 6 months</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-weekly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-finite-subscription-on-sale-weekly.html
@@ -31,6 +31,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every week for 6 weeks <span class="original-price"><span class="sqs-money-native">200.00</span> every week for 6 weeks</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every week for 6 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every week for 6 weeks</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-bi-monthly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-bi-monthly.html
@@ -25,6 +25,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every 2 months <span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 months <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 months</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-bi-weekly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-bi-weekly.html
@@ -25,6 +25,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every 2 weeks <span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every 2 weeks <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every 2 weeks</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-monthly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-monthly.html
@@ -25,6 +25,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every month <span class="original-price"><span class="sqs-money-native">200.00</span> every month</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every month <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every month</span>
 
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-weekly.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-price-subscription-on-sale-weekly.html
@@ -25,6 +25,6 @@
 
 :OUTPUT
 <div class="product-price">
-<span class="sqs-money-native">50.00</span> every week <span class="original-price"><span class="sqs-money-native">200.00</span> every week</span>
+<span class="visually-hidden v6-visually-hidden">Sale Price:</span><span class="sqs-money-native">50.00</span> every week <span class="visually-hidden v6-visually-hidden">Original Price:</span><span class="original-price"><span class="sqs-money-native">200.00</span> every week</span>
 
 </div>


### PR DESCRIPTION
For more context on the changes, see comments thread in the ticket: https://jira.squarespace.net/browse/COM-10948
or https://a11yproject.com/posts/how-to-hide-content/

There is no visible change as part of the changes, this change is to assist those users who rely on screen readers.