### PR TITLE
Add radio button layout to variants-select formatter

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -13,6 +13,10 @@
         {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
     </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="{name|htmltag}">{.repeated section values}
+      <input type="radio" class="variant-radiobtn" value="{@|htmltag}" name="variant-option-{name|htmltag}" id="variant-option-{name|htmltag}-{@|htmltag}"/>
+      <label for="variant-option-{name|htmltag}-{@|htmltag}">{@|htmltag}</label>{.end}
+    </div>
     </div>{.end}
   </div>
 {.end}

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -25,6 +25,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -33,6 +39,12 @@
         <option value="">Select fit</option>
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -25,6 +25,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -33,6 +39,12 @@
         <option value="">Select fit</option>
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -25,6 +25,12 @@
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">color: </div>
@@ -33,6 +39,12 @@
         <option value="">Select color</option>
         <option value="blue">blue</option><option value="red">red</option>
       </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -32,6 +32,12 @@
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
+      <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
+      <label for="variant-option-color-blue">blue</label>
+      <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
+      <label for="variant-option-color-red">red</label>
+    </div>
     </div>
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
@@ -40,6 +46,12 @@
         <option value="">Select fit</option>
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
+      <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
+      <label for="variant-option-fit-loose">loose</label>
+      <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
+      <label for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds the markup to render an alternate layout for the variant-select formatter. To avoid this markup displaying on sites, we are running a global CSS invalidation with new style rules to hide this markup by default. 