### PR TITLE
[CMS-38076] - update template compiler to output srcset instead of data-srcset

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -496,7 +496,7 @@ public class ContentFormatters implements FormatterRegistry {
         return;
       }
 
-      buf.append(" data-srcset=\"");
+      buf.append(" srcset=\"");
       for (int i = 0; i < limit; i++) {
         if (i > 0) {
           buf.append(',');

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
@@ -9,5 +9,5 @@
 {@|image-srcset 1}
 
 :OUTPUT
-data-srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w"
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w"
 


### PR DESCRIPTION
This is in relation to Zach Gawlik's PR here: https://github.com/Squarespace/template-engine/pull/3/files

Currently, the JSON-T compiler outputs `data-srcset="..."`
This PR changes the compiler to output with srcset and not the data-attribute so that ImageLoader JS does not need to run and set the srcset attribute,