### PR TITLE
[CMS-39266] Truncate content item body if longer than 1000 characters when determining alt-text

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -58,6 +58,8 @@ import com.squarespace.template.plugins.platform.enums.RecordType;
  */
 public class ContentFormatters implements FormatterRegistry {
 
+  public static final int MAX_ALT_TEXT_LENGTH = 1000;
+
   @Override
   public void registerFormatters(SymbolTable<StringView, Formatter> table) {
     table.add(new AbsUrlFormatter(Constants.BASE_URL_KEY));
@@ -274,7 +276,7 @@ public class ContentFormatters implements FormatterRegistry {
     if (isTruthy(body)) {
       String text = PluginUtils.removeTags(body.asText());
       if (text.length() > 0) {
-        return text;
+        return text.substring(0, Math.min(text.length(), MAX_ALT_TEXT_LENGTH));
       }
     }
 

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -95,7 +95,9 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
         "f-image-1.html",
         "f-image-2.html",
         "f-image-3.html",
-        "f-image-4.html"
+        "f-image-4.html",
+        "f-image-5.html",
+        "f-image-6.html"
         );
   }
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-5.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-5.html
@@ -1,0 +1,23 @@
+:COMMENTS
+should print alt text from image.body if title is missing. Multiple whitespace characters should be reduced to 1
+
+:JSON
+{
+  "img": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "title": "",
+    "originalSize": 1000,
+    "assetUrl": "/foo/bar.jpg",
+    "mediaFocalPoint": {"x": 0.3, "y": 0.7},
+    "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa."
+},
+  "info": {
+    "something": "else"
+  }
+}
+
+:TEMPLATE
+{img|image foo-bar-image}
+
+:OUTPUT
+<noscript><img src="/foo/bar.jpg" alt="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa." /></noscript><img class="foo-bar-image" data-src="/foo/bar.jpg" data-image="/foo/bar.jpg" data-image-dimensions="1000" data-image-focal-point="0.3,0.7" alt="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa." data-load="false" data-image-id="560c37c1a7c8465c4a71d99a" data-type="image" />

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-6.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-6.html
@@ -1,0 +1,23 @@
+:COMMENTS
+should print truncated alt text from image.body if title is missing and body length is more than 1000 characters
+
+:JSON
+{
+  "img": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "title": "",
+    "originalSize": 1000,
+    "assetUrl": "/foo/bar.jpg",
+    "mediaFocalPoint": {"x": 0.3, "y": 0.7},
+    "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean condimentum duis egestas felis placerat quisque nulla vestibulum aenean posuere vivamus diam semper aenean Consectetuer. Pede senectus sagittis turpis nulla, ultrices ultrices laoreet integer parturient tristique aliquet. Suscipit Id libero magna tempor in porttitor sagittis at, metus tempor dapibus vestibulum, mollis sed lacus Risus rutrum pede hendrerit semper felis primis fames nam et. Phasellus nulla dapibus dictum. Leo cum suscipit. Sed maecenas vitae senectus auctor ipsum. Cursus erat, habitant lacus diam blandit odio fermentum faucibus euismod porttitor a hymenaeos lobortis vulputate nullam vestibulum euismod neque nullam Donec fermentum varius egestas justo. Natoque ipsum penatibus magnis nunc odio. Aenean, gravida et. Habitant. Curae; augue. Nullam pulvinar ligula magna auctor etiam bibendum dictum. Blandit parturient mollis at. Neque auctor penatibus metus. Erat viverra puribus. THIS DOES NOT SHOW UP"
+},
+  "info": {
+    "something": "else"
+  }
+}
+
+:TEMPLATE
+{img|image foo-bar-image}
+
+:OUTPUT
+<noscript><img src="/foo/bar.jpg" alt="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean condimentum duis egestas felis placerat quisque nulla vestibulum aenean posuere vivamus diam semper aenean Consectetuer. Pede senectus sagittis turpis nulla, ultrices ultrices laoreet integer parturient tristique aliquet. Suscipit Id libero magna tempor in porttitor sagittis at, metus tempor dapibus vestibulum, mollis sed lacus Risus rutrum pede hendrerit semper felis primis fames nam et. Phasellus nulla dapibus dictum. Leo cum suscipit. Sed maecenas vitae senectus auctor ipsum. Cursus erat, habitant lacus diam blandit odio fermentum faucibus euismod porttitor a hymenaeos lobortis vulputate nullam vestibulum euismod neque nullam Donec fermentum varius egestas justo. Natoque ipsum penatibus magnis nunc odio. Aenean, gravida et. Habitant. Curae; augue. Nullam pulvinar ligula magna auctor etiam bibendum dictum. Blandit parturient mollis at. Neque auctor penatibus metus. Erat viverra puribus." /></noscript><img class="foo-bar-image" data-src="/foo/bar.jpg" data-image="/foo/bar.jpg" data-image-dimensions="1000" data-image-focal-point="0.3,0.7" alt="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean condimentum duis egestas felis placerat quisque nulla vestibulum aenean posuere vivamus diam semper aenean Consectetuer. Pede senectus sagittis turpis nulla, ultrices ultrices laoreet integer parturient tristique aliquet. Suscipit Id libero magna tempor in porttitor sagittis at, metus tempor dapibus vestibulum, mollis sed lacus Risus rutrum pede hendrerit semper felis primis fames nam et. Phasellus nulla dapibus dictum. Leo cum suscipit. Sed maecenas vitae senectus auctor ipsum. Cursus erat, habitant lacus diam blandit odio fermentum faucibus euismod porttitor a hymenaeos lobortis vulputate nullam vestibulum euismod neque nullam Donec fermentum varius egestas justo. Natoque ipsum penatibus magnis nunc odio. Aenean, gravida et. Habitant. Curae; augue. Nullam pulvinar ligula magna auctor etiam bibendum dictum. Blandit parturient mollis at. Neque auctor penatibus metus. Erat viverra puribus." data-load="false" data-image-id="560c37c1a7c8465c4a71d99a" data-type="image" />


### PR DESCRIPTION
when determining alt-text for an image on a contentItem, we fallback to the contentItem.body field if the title is missing. This is documented behavior in the [KB](**url**). However, if the body field is very long (e.g. in the case of a blog post), it results in slow loading issues that we have been observing on the platform. 

This PR truncates the body field to < 1000 characters, after any HTML tags have been removed. 

**Verifications:**

1. Added tests to verify that item body is used and truncated
2. test on local site-server


