### PR TITLE
Output the original format with no size declared

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -505,6 +505,10 @@ public class ContentFormatters implements FormatterRegistry {
         }
         buf.append(assetUrl).append("?format=").append(variants[i]).append(" ").append(variants[i]);
       }
+
+      buf.append(',');
+      buf.append(assetUrl).append("?format=original");
+
       buf.append("\"");
     }
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
@@ -9,5 +9,5 @@
 {@|image-srcset 1}
 
 :OUTPUT
-srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w"
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=original"
 


### PR DESCRIPTION
This covers a case such as:

- User uploads image 215px wide
- Browser is rendering 400px
- We only generate 100w because we don't scale up to next size (300w)
- Browser ends up request 100w instead of original

By outputting all the sizes that we have generated and finally the originally, we serve the highest available size that we have in the above case.