### PR TITLE
Products - Quantity input doesn't have a label

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/quantity-input.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/quantity-input.html
@@ -1,6 +1,10 @@
 {.var @quantityLabel localizedStrings.productQuantityInputLabel}
+{##
+  We use aria-label for the input below since we didn't want to change the div above and potentially break user sites.
+  And it was hard to guarantee unique ids for using aria-labelledby
+##}
 
 <div class="product-quantity-input" data-item-id="{id}" data-animation-role="content">
   <div class="quantity-label">{.if @quantityLabel}{@quantityLabel}{.or}Quantity{.end}:</div>
-  <input size="4" max="9999" min="1" value="1" type="number" step="1"></input>
+  <input aria-label="{.if @quantityLabel}{@quantityLabel}{.or}Quantity{.end}" size="4" max="9999" min="1" value="1" type="number" step="1"></input>
 </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-quantity-input-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-quantity-input-1.html
@@ -19,6 +19,6 @@
 :OUTPUT
 <div class="product-quantity-input" data-item-id="560c37c1a7c8465c4a71d99a" data-animation-role="content">
   <div class="quantity-label">Quantity:</div>
-  <input size="4" max="9999" min="1" value="1" type="number" step="1"></input>
+  <input aria-label="Quantity" size="4" max="9999" min="1" value="1" type="number" step="1"></input>
 </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-quantity-input-4.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-quantity-input-4.html
@@ -18,5 +18,5 @@
 :OUTPUT
 <div class="product-quantity-input" data-item-id="560c37c1a7c8465c4a71d99a" data-animation-role="content">
   <div class="quantity-label">Quantity:</div>
-  <input size="4" max="9999" min="1" value="1" type="number" step="1"></input>
+  <input aria-label="Quantity" size="4" max="9999" min="1" value="1" type="number" step="1"></input>
 </div>


### PR DESCRIPTION
On the products detail page, the Quantity label is linked with the input visually, but not semantically. A screen reader user landing on this input will not know that it's a quantity input.

The change makes it so that the are semantically linked.
There will be follow-up PRs for style changes in new-bedford and v6 (those changes will be backwards-compatible, so those will go in first).
EDIT: I updated this PR so that style changes won't be required. So no additional changes will be necessary beyond just the ones in this PR.

Ticket: https://jira.squarespace.net/browse/COM-9030