### PR TITLE
[VULN-414] Sanitize product option title

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -6,7 +6,7 @@
 
   <div class="product-variants" data-item-id="{item.id}" data-variants="{@variants|json|htmltag}"{.if @isSubscribable} data-is-subscribable="true" data-subscription-plan="{@subscriptionPlan|json|htmltag}"{.end} data-animation-role="content">{.repeated section options}
     <div class="variant-option">
-    <div class="variant-option-title">{name}: </div>
+    <div class="variant-option-title">{name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
         <option value="">{selectText|message variantName:name}</option>
@@ -20,4 +20,3 @@
     </div>{.end}
   </div>
 {.end}
-


### PR DESCRIPTION
This PR adds the html formatter to the product variant option titles for sanitization. The only real change is changing this line ` <div class="variant-option-title">{name}: </div>` to `<div class="variant-option-title">{name|htmltag}: </div>`. The rest is cleaning up where the loops start and end, as well as the indentations within it to be more readable.