### PR TITLE
VULN-329: Escape custom out of stock messages

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -539,7 +539,7 @@ public class CommerceFormatters implements FormatterRegistry {
         String defaultSoldOutMessage = StringUtils.defaultIfEmpty(defaultSoldOutText, "sold out");
         String soldOutMessage = StringUtils.defaultIfEmpty(customSoldOutMessage, defaultSoldOutMessage);
         buf.append("<div class=\"product-mark sold-out\">");
-        buf.append(soldOutMessage);
+        PluginUtils.escapeHtmlAttribute(soldOutMessage, buf);
         buf.append("</div>");
         var.set(buf);
       } else if (CommerceUtils.isOnSale(node)) {

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-status-9.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-status-9.html
@@ -9,7 +9,7 @@
   },
   "productMerchandisingContext": {
     "560c37c1a7c8465c4a71d99a": {
-      "customSoldOutText": "Custom sold out text"
+      "customSoldOutText": "<script>Custom sold out text</script>"
     }
   }
 }
@@ -18,5 +18,5 @@
 {@|product-status}
 
 :OUTPUT
-<div class="product-mark sold-out">Custom sold out text</div>
+<div class="product-mark sold-out">&lt;script&gt;Custom sold out text&lt;/script&gt;</div>
 


### PR DESCRIPTION
### Description
This PR adds HTML escaping when outputting the custom out of stock message for products and updates the test case. I'm using `PluginUtils.escapeHtmlAttribute` to do the escaping, which is used by the `htmltag` and `htmlattr` formatters.

### JIRA
VULN-329