### PR TITLE
I18NPROD-322-add-method-to-format-value-for-gift-card

### DIFF
--- a/core/src/main/java/com/squarespace/template/Constants.java
+++ b/core/src/main/java/com/squarespace/template/Constants.java
@@ -102,6 +102,10 @@ public class Constants {
       "localizedStrings", "giftCardVariantSelectText"
   };
 
+  public static final String[] GIFT_CARD_VALUE_DISPLAY_TEXT = new String[] {
+      "localizedStrings", "giftCardValueDisplayText"
+  };
+
   public static final String[] CLDR_MONEYFORMAT_KEY = new String[] {
       "website", "useCLDRMoneyFormat" };
 

--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -647,7 +647,7 @@ public class CommerceFormatters implements FormatterRegistry {
 
       ObjectNode obj = JsonUtils.createObjectNode();
       obj.set("item", node);
-      obj.set("displayName", getDisplayText(ctx, node));
+      obj.set("displayText", getDisplayText(ctx, node));
       obj.set("options", options);
       obj.set("selectText", getSelectText(ctx, node));
       var.set(executeTemplate(ctx, template, obj, false));

--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -646,13 +646,13 @@ public class CommerceFormatters implements FormatterRegistry {
 
       ObjectNode obj = JsonUtils.createObjectNode();
       obj.set("item", node);
-      obj.set("displayName", getDisplayName(ctx, node));
+      obj.set("displayName", getDisplayText(ctx, node));
       obj.set("options", options);
       obj.set("selectText", getSelectText(ctx, node));
       var.set(executeTemplate(ctx, template, obj, false));
     }
 
-    private static TextNode getDisplayName(Context ctx, JsonNode node) {
+    private static TextNode getDisplayText(Context ctx, JsonNode node) {
       ProductType productType = CommerceUtils.getProductType(node);
       // Gift Cards have variants forcibly named "Value" by default (as opposed to a merchant-defined variant name) and
       // this string must be translated before being displayed on the front-end.

--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -621,6 +621,7 @@ public class CommerceFormatters implements FormatterRegistry {
   protected static class VariantsSelectFormatter extends BaseFormatter {
 
     private Instruction template;
+    private static final TextNode NAME_NODE = new TextNode("{name}");
 
     public VariantsSelectFormatter() {
       super("variants-select", false);
@@ -659,9 +660,8 @@ public class CommerceFormatters implements FormatterRegistry {
       if (productType == ProductType.GIFT_CARD) {
         String localizedDisplayName = ctx.resolve(Constants.GIFT_CARD_VALUE_DISPLAY_TEXT).asText();
         return new TextNode(StringUtils.defaultIfEmpty(localizedDisplayName, "Value"));
-      } else {
-        return new TextNode(StringUtils.defaultString("{name}"));
       }
+      return NAME_NODE;
     }
 
     private static TextNode getSelectText(Context ctx, JsonNode node) {

--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -646,9 +646,22 @@ public class CommerceFormatters implements FormatterRegistry {
 
       ObjectNode obj = JsonUtils.createObjectNode();
       obj.set("item", node);
+      obj.set("displayName", getDisplayName(ctx, node));
       obj.set("options", options);
       obj.set("selectText", getSelectText(ctx, node));
       var.set(executeTemplate(ctx, template, obj, false));
+    }
+
+    private static TextNode getDisplayName(Context ctx, JsonNode node) {
+      ProductType productType = CommerceUtils.getProductType(node);
+      // Gift Cards have variants forcibly named "Value" by default (as opposed to a merchant-defined variant name) and
+      // this string must be translated before being displayed on the front-end.
+      if (productType == ProductType.GIFT_CARD) {
+        String localizedDisplayName = ctx.resolve(Constants.GIFT_CARD_VALUE_DISPLAY_TEXT).asText();
+        return new TextNode(StringUtils.defaultIfEmpty(localizedDisplayName, "Value"));
+      } else {
+        return new TextNode(StringUtils.defaultString("{name}"));
+      }
     }
 
     private static TextNode getSelectText(Context ctx, JsonNode node) {

--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -6,7 +6,7 @@
 
   <div class="product-variants" data-item-id="{item.id}" data-variants="{@variants|json|htmltag}"{.if @isSubscribable} data-is-subscribable="true" data-subscription-plan="{@subscriptionPlan|json|htmltag}"{.end} data-animation-role="content">{.repeated section options}
     <div class="variant-option">
-    <div class="variant-option-title">{displayName|message name:name|htmltag}: </div>
+    <div class="variant-option-title">{displayText|message name:name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
         <option value="">{selectText|message variantName:name}</option>

--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -6,7 +6,7 @@
 
   <div class="product-variants" data-item-id="{item.id}" data-variants="{@variants|json|htmltag}"{.if @isSubscribable} data-is-subscribable="true" data-subscription-plan="{@subscriptionPlan|json|htmltag}"{.end} data-animation-role="content">{.repeated section options}
     <div class="variant-option">
-    <div class="variant-option-title">{name|htmltag}: </div>
+    <div class="variant-option-title">{displayName|message name:name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
         <option value="">{selectText|message variantName:name}</option>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-4.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-4.html
@@ -1,12 +1,12 @@
 :JSON
 {
   "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar"
+    "productVariantSelectText": "Get foobar"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
     "structuredContent": {
-      "productType": 4,
+      "productType": 1,
       "variants": [
         {"attributes": { "fit": "loose", "color": "blue" }},
         {"attributes": { "fit": "slim", "color": "red" }}

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
@@ -1,12 +1,12 @@
 :JSON
 {
-  "localizedStrings": {
-    "giftCardVariantSelectText": "Get foobar"
+"localizedStrings": {
+    "productVariantSelectText": "Select {variantName}"
   },
   "item": {
     "id": "560c37c1a7c8465c4a71d99a",
     "structuredContent": {
-      "productType": 4,
+      "productType": 1,
       "variants": [
         {"attributes": { "fit": "loose", "color&hue": "blue" }},
         {"attributes": { "fit": "slim", "color&hue": "red" }}
@@ -24,8 +24,8 @@
     <div class="variant-option">
     <div class="variant-option-title">fit: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get foobar" data-variant-option-name="fit">
-        <option value="">Get foobar</option>
+      <select aria-label="Select fit" data-variant-option-name="fit">
+        <option value="">Select fit</option>
         <option value="loose">loose</option><option value="slim">slim</option>
       </select>
     </div>
@@ -39,8 +39,8 @@
     <div class="variant-option">
     <div class="variant-option-title">color&amp;hue: </div>
     <div class="variant-select-wrapper">
-      <select aria-label="Get foobar" data-variant-option-name="color&amp;hue">
-        <option value="">Get foobar</option>
+      <select aria-label="Select color&hue" data-variant-option-name="color&amp;hue">
+        <option value="">Select color&hue</option>
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
@@ -1,18 +1,19 @@
 :JSON
 {
   "localizedStrings": {
-    "giftCardValueDisplayText": "Value Display Text",
+    "giftCardValueDisplayText": "Test Value",
     "giftCardVariantSelectText": "Get foobar"
   },
   "item": {
-    "id": "560c37c1a7c8465c4a71d99a",
-    "structuredContent": {
-      "productType": 4,
-      "variants": [
-        {"attributes": { "Value": "$25.00", "Value": "$50.00" }}
-      ],
-      "variantOptionOrdering": ["Value"]
-    }
+  "id": "560c37c1a7c8465c4a71d99a",
+  "structuredContent": {
+    "productType": 4,
+    "variants": [
+      {"attributes": { "Value": "25" }},
+      {"attributes": { "Value": "50" }}
+    ],
+  "variantOptionOrdering": ["Value"]
+  }
   }
 }
 
@@ -20,20 +21,20 @@
 {item|variants-select}
 
 :OUTPUT
-<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Value&quot;:&quot;50&quot;},{&quot;Value&quot;:&quot;25&quot;}}]" data-animation-role="content">
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Value&quot;:&quot;25&quot;}},{&quot;attributes&quot;:{&quot;Value&quot;:&quot;50&quot;}}]" data-animation-role="content">
     <div class="variant-option">
-        <div class="variant-option-title">Value Display Text: </div>
-        <div class="variant-select-wrapper">
-            <select aria-label="Get foobar" data-variant-option-name="Value">
-                <option value="">Get foobar</option>
-                <option value="$25.00">$25.00</option><option value="$50.00">$50.00</option>
-            </select>
-        </div>
-        <div class="variant-radiobtn-wrapper" data-variant-option-name="Value">
-            <input type="radio" class="variant-radiobtn" value="$25.00" name="variant-option-Value" id="variant-option-Value-$25.00"/>
-            <label for="variant-option-Value-$25.00">$25.00</label>
-            <input type="radio" class="variant-radiobtn" value="$50.00" name="variant-option-Value" id="variant-option-Value-$50.00"/>
-            <label for="variant-option-Value-$50.00">$50.00</label>
-        </div>
+    <div class="variant-option-title">Test Value: </div>
+    <div class="variant-select-wrapper">
+      <select aria-label="Get foobar" data-variant-option-name="Value">
+        <option value="">Get foobar</option>
+        <option value="25">25</option><option value="50">50</option>
+      </select>
     </div>
-</div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Value">
+      <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Value" id="variant-option-Value-25"/>
+      <label for="variant-option-Value-25">25</label>
+      <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Value" id="variant-option-Value-50"/>
+      <label for="variant-option-Value-50">50</label>
+    </div>
+    </div>
+  </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
@@ -1,0 +1,39 @@
+:JSON
+{
+  "localizedStrings": {
+    "giftCardValueDisplayText": "Value Display Text",
+    "giftCardVariantSelectText": "Get foobar"
+  },
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "productType": 4,
+      "variants": [
+        {"attributes": { "Value": "$25.00", "Value": "$50.00" }}
+      ],
+      "variantOptionOrdering": ["Value"]
+    }
+  }
+}
+
+:TEMPLATE
+{item|variants-select}
+
+:OUTPUT
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Value&quot;:&quot;50&quot;},{&quot;Value&quot;:&quot;25&quot;}}]" data-animation-role="content">
+    <div class="variant-option">
+        <div class="variant-option-title">Value Display Text: </div>
+        <div class="variant-select-wrapper">
+            <select aria-label="Get foobar" data-variant-option-name="Value">
+                <option value="">Get foobar</option>
+                <option value="$25.00">$25.00</option><option value="$50.00">$50.00</option>
+            </select>
+        </div>
+        <div class="variant-radiobtn-wrapper" data-variant-option-name="Value">
+            <input type="radio" class="variant-radiobtn" value="$25.00" name="variant-option-Value" id="variant-option-Value-$25.00"/>
+            <label for="variant-option-Value-$25.00">$25.00</label>
+            <input type="radio" class="variant-radiobtn" value="$50.00" name="variant-option-Value" id="variant-option-Value-$50.00"/>
+            <label for="variant-option-Value-$50.00">$50.00</label>
+        </div>
+    </div>
+</div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-7.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-7.html
@@ -1,0 +1,40 @@
+:JSON
+{
+  "localizedStrings": {
+    "giftCardValueDisplayText": "Test Value",
+    "giftCardVariantSelectText": "Get foobar"
+  },
+  "item": {
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "productType": 1,
+      "variants": [
+        {"attributes": { "Color": "Blue" }},
+        {"attributes": { "Color": "Pink" }}
+      ],
+      "variantOptionOrdering": ["Color"]
+    }
+  }
+}
+
+:TEMPLATE
+{item|variants-select}
+
+:OUTPUT
+<div class="product-variants" data-item-id="560c37c1a7c8465c4a71d99a" data-variants="[{&quot;attributes&quot;:{&quot;Color&quot;:&quot;Blue&quot;}},{&quot;attributes&quot;:{&quot;Color&quot;:&quot;Pink&quot;}}]" data-animation-role="content">
+    <div class="variant-option">
+    <div class="variant-option-title">Color: </div>
+    <div class="variant-select-wrapper">
+      <select aria-label="Select Color" data-variant-option-name="Color">
+        <option value="">Select Color</option>
+        <option value="Blue">Blue</option><option value="Pink">Pink</option>
+      </select>
+    </div>
+    <div class="variant-radiobtn-wrapper" data-variant-option-name="Color">
+      <input type="radio" class="variant-radiobtn" value="Blue" name="variant-option-Color" id="variant-option-Color-Blue"/>
+      <label for="variant-option-Color-Blue">Blue</label>
+      <input type="radio" class="variant-radiobtn" value="Pink" name="variant-option-Color" id="variant-option-Color-Pink"/>
+      <label for="variant-option-Color-Pink">Pink</label>
+    </div>
+    </div>
+  </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/get-item-variant-options.json
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/get-item-variant-options.json
@@ -80,4 +80,21 @@
     {"name": "color", "values": ["blue", "red"]}
 ]
 
+:getItemVariant-6
+{
+    "id": "560c37c1a7c8465c4a71d99a",
+    "structuredContent": {
+      "variants": [
+        {"attributes": { "Value": "25" }},
+        {"attributes": { "Value": "50" }}
+      ],
+    "variantOptionOrdering": ["Value"]
+  }
+}
+
+:getItemVariant-6-expected
+[
+    {"name": "Value", "values": ["25", "50"]}
+]
+
 


### PR DESCRIPTION
## What does this PR do?

Adds a method to `CommerceFormatters.java` that translates the "Value" string displayed when a product is a gift card and defaults to the user input variant name otherwise.

## Why is this important?

Currently there is a bug where the text above the gift card option drop-down displayed "Value" in English in all languages. This formatting method solves this bug.

## What high level changes did you make to the code to accomplish that goal?

* Added a method to `CommerceFormatters.java` that resolves the `displayName` based on the locale if a product is a gift card type otherwise it returns the `name` of the variant
* Changed the `variant-option-title` tag within `variants-select.html` to `{displayName}` with a default to `name` for non-gift card product types.

## Anything else?

This change also required adding the string `Value` to the `products-en-US.json` and `products-2.0-en-US.json` files within site-server to be translated into all languages. That PR can be found [here](https://github.com/sqsp/squarespace-v6/pull/11407) and will need to be merged and have translations returned before these changes are incorporated.

## How was this tested?

- [X] Made local changes to template-compiler and ran site-server with the local snapshot of template-compiler changes
- [X] Created a gift card locally and verified the translated text showed
- [X] Created a physical product with a unique variant name and verified that name displayed
- [X] Created a product with the suggested variant name and verified it displayed
- [x] Write additional tests for this functionality 

### Screenshots

<img width="248" alt="Screen Shot 2021-07-22 at 10 17 21 AM" src="https://user-images.githubusercontent.com/12403370/126662659-9d090739-86d5-48d5-9bff-f431bbdd3149.png">
<img width="397" alt="Screen Shot 2021-07-22 at 10 17 52 AM" src="https://user-images.githubusercontent.com/12403370/126662678-61b33f0d-a7d6-41f5-8a8d-786d424fe0f6.png">
<img width="472" alt="Screen Shot 2021-07-22 at 11 09 05 AM" src="https://user-images.githubusercontent.com/12403370/126662839-9d73af8c-63c4-4d03-846b-f8d084eafac9.png">
