### PR TITLE
PERF-2091: Ensure all srcset image candidate has width descriptor

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -467,6 +467,7 @@ public class ContentFormatters implements FormatterRegistry {
   }
 
   public static class ImageMetaSrcSetFormatter extends BaseFormatter {
+    private String[] SQUARESPACE_SIZES = {"100w", "300w", "500w", "750w", "1000w", "1500w", "2500w"};
 
     public ImageMetaSrcSetFormatter() {
       super("image-srcset", false);
@@ -502,11 +503,28 @@ public class ContentFormatters implements FormatterRegistry {
         }
         buf.append(assetUrl).append("?format=").append(variants[i]).append(" ").append(variants[i]);
       }
-
-      buf.append(',');
-      buf.append(assetUrl).append("?format=original");
+      addOriginalImageFormat(buf, variants, limit, assetUrl);
 
       buf.append("\"");
+    }
+
+    /**
+     * Not all images will have complete list of Squarespace sizes due to original uploaded image is already too small. So no compression
+     * or smaller image size is produced.
+     * For these cases, we want to use the original image for missing sizes by setting the next size to use original image.
+     */
+    public void addOriginalImageFormat(StringBuilder buf, String[] variants, int limit, String assetUrl) {
+      String lastVariant = variants[limit - 1];
+      if (lastVariant.equals(SQUARESPACE_SIZES[SQUARESPACE_SIZES.length - 1])) {
+        return;
+      }
+      for (int i = 0; i < SQUARESPACE_SIZES.length - 1; i++) {
+        if (SQUARESPACE_SIZES[i].equals(lastVariant)) {
+          buf.append(',');
+          buf.append(assetUrl).append("?format=original").append(" ").append(SQUARESPACE_SIZES[i + 1]);
+          return;
+        }
+      }
     }
 
     @Override

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -125,7 +125,8 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
   public void testSrcSet() {
     runner.run(
         "f-image-src-set-1.html",
-        "f-image-src-set-2.html"
+        "f-image-src-set-2.html",
+        "f-image-src-set-3.html"
         );
   }
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-1.html
@@ -9,5 +9,5 @@
 {@|image-srcset 1}
 
 :OUTPUT
-srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=original"
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=original 2500w"
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-3.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-image-src-set-3.html
@@ -1,0 +1,13 @@
+:JSON
+{
+  "assetUrl": "/foo/bar.jpg",
+  "systemDataVariants": "1500x983,100w,300w,500w,750w,1000w,1500w,2500w"
+}
+
+
+:TEMPLATE
+{@|image-srcset 1}
+
+:OUTPUT
+srcset="/foo/bar.jpg?format=100w 100w,/foo/bar.jpg?format=300w 300w,/foo/bar.jpg?format=500w 500w,/foo/bar.jpg?format=750w 750w,/foo/bar.jpg?format=1000w 1000w,/foo/bar.jpg?format=1500w 1500w,/foo/bar.jpg?format=2500w 2500w"
+


### PR DESCRIPTION
We are currently adding orignal image candidate to srcset without width descriptor. This PR adds the next Squarespace image size width descriptor to srcset's original image candidate and avoid adding original image candidate if 2500w is already set because 2500w is already the biggest size we support (it is probably same image as orginal too). 

According to scrset spec https://html.spec.whatwg.org/multipage/images.html#image-candidate-string, srcset attribute for original image format should have width descriptor for our case.

> If an image candidate string for an element has the width descriptor specified, all other image candidate strings for that element must also have the width descriptor specified.

> If an element has a sizes attribute present, all image candidate strings for that element must have the width descriptor specified.

Our srcset attribute has all the width descriptor except for the last original format. This has caused some unexpected behavior. 

1.  In device with device pixel ratio of 1, original image is always requested instead of based on screen width. See screenshot below for https://www.akashagoods.com/ with DPR set to 1.0
![Screen Shot 2021-08-19 at 12 22 46 PM](https://user-images.githubusercontent.com/59619684/130127683-d19bfd0c-d5dd-422a-821e-aa0b815ca532.png)

2. In desktop mode, and for some websites, although 2500w image is available, chrome will choose orignal image instead 2500w image. See screenshots for https://cobalt-dog-78tl.squarespace.com/
![Screen Shot 2021-08-19 at 12 25 15 PM](https://user-images.githubusercontent.com/59619684/130127748-6f84d45c-88b8-42f6-af61-b481cc292469.png)

The last original image src should always have width descriptor to avoid these unexpected behavior.