### PR TITLE
VULN-414: Escape custom option names

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -9,7 +9,7 @@
     <div class="variant-option-title">{displayText|message name:name|htmltag}: </div>
     <div class="variant-select-wrapper">
       <select aria-label="{selectText|message variantName:name}" data-variant-option-name="{name|htmltag}">
-        <option value="">{selectText|message variantName:name}</option>
+        <option value="">{selectText|message variantName:name|htmltag}</option>
         {.repeated section values}<option value="{@|htmltag}">{@|htmltag}</option>{.end}
       </select>
     </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
@@ -40,7 +40,7 @@
     <div class="variant-option-title">color&amp;hue: </div>
     <div class="variant-select-wrapper">
       <select aria-label="Select color&hue" data-variant-option-name="color&amp;hue">
-        <option value="">Select color&hue</option>
+        <option value="">Select color&amp;hue</option>
         <option value="blue">blue</option><option value="red">red</option>
       </select>
     </div>


### PR DESCRIPTION
This PR escapes custom option names in the variant select formatter to prevent potential XSS attacks.

VULN ticket: https://squarespace.atlassian.net/browse/VULN-414