### PR TITLE
I18NPROD-1685 - Update the useCLDRMoneyFormat flag check

### DIFF
--- a/core/src/main/java/com/squarespace/template/Constants.java
+++ b/core/src/main/java/com/squarespace/template/Constants.java
@@ -107,7 +107,7 @@ public class Constants {
   };
 
   public static final String[] CLDR_MONEYFORMAT_KEY = new String[] {
-      "website", "useCLDRMoneyFormat" };
+      "featureFlags", "useCLDRMoneyFormat" };
 
   public static final String[] PRODUCT_RESTOCK_NOTIFICATION_SIGN_UP_TEXT = new String[] {
       "localizedStrings", "productRestockNotificationSignUpText"

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MoneyFormatterTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MoneyFormatterTest.java
@@ -48,7 +48,7 @@ public class MoneyFormatterTest extends PlatformUnitTestBase {
   @Test
   public void testExecutor() throws CodeException {
     String json = "{\"amt\": {\"value\": \"-15789.12\", \"currency\": \"USD\"}, "
-         + "\"website\": {\"useCLDRMoneyFormat\": true}}";
+         + "\"featureFlags\": {\"useCLDRMoneyFormat\": true}}";
     String template = "{amt|money style:short mode:significant}";
 
     assertEquals(executeLocale(template, json, "fr"), "-16 k $US");


### PR DESCRIPTION
## Update the `useCLDRMoneyFormat` flag check

### [I18NPROD-1685](https://squarespace.atlassian.net/browse/I18NPROD-1684)
<!-- If you don't have a ticket already, please create one in your team board and link it here. This is required for SOX compliance -->

### Description
This is a follow up to an [outstanding pr](https://github.com/sqsp/squarespace-v6/pull/24785) where we pass `featureFlags.useCLDRMoneyFormat` into template compiler. The work included here is updating `CLDR_MONEYFORMAT_KEY` to check under `featureFlags` (open to naming suggestions) instead of `website`.

### Why are we doing this?
Placing `useCLDRMoneyFormat` under `website` has unintended consequences in certain situations. Mainly when template code checks the presence of `website` to determine rendering paths. This specifically became an issue when rendering the [form.block](https://github.com/sqsp/squarespace-v6/blob/master/site-server/src/main/webapp/templates-v6/system/blocks/form.block#L164-L178). This caused an additional form field to render since `useCLDRMoneyFormat` needed to exist in `website`.

I decided to create an explicit field named `featureFlags` to prevent a template name collusion in the future.
