### PR TITLE
[CMS-45395] - add HSLA Color formatter

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -335,7 +335,7 @@ public class ContentFormatters implements FormatterRegistry {
       JsonNode node = var.node();
       boolean hasAlphaValue = false;
 
-      int hue = node.path("hue").asInt();
+      double hue = node.path("hue").asDouble();
       double saturation = node.path("saturation").asDouble();
       double lightness = node.path("lightness").asDouble();
       JsonNode alphaNode = node.path("alpha");
@@ -381,7 +381,7 @@ public class ContentFormatters implements FormatterRegistry {
         buf.append("hsl(");
       }
 
-      buf.append(hue);
+      buf.append(format.format(hue));
       buf.append(", ");
       buf.append(format.format(saturation));
       buf.append("%, ");

--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -21,6 +21,8 @@ import static com.squarespace.template.GeneralUtils.isTruthy;
 import static com.squarespace.template.GeneralUtils.loadResource;
 import static com.squarespace.template.plugins.PluginUtils.slugify;
 
+import java.text.DecimalFormat;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -71,6 +73,7 @@ public class ContentFormatters implements FormatterRegistry {
     table.add(new ColorWeightFormatter());
     table.add(new CoverImageMetaFormatter());
     table.add(new HeightFormatter());
+    table.add(new HslaColorFormatter());
     table.add(new HumanizeDurationFormatter());
     table.add(new ImageFormatter());
     table.add(new ImageColorFormatter());
@@ -317,6 +320,44 @@ public class ContentFormatters implements FormatterRegistry {
         int height = Integer.parseInt(parts[1]);
         var.set(height);
       }
+    }
+  };
+
+  public static class HslaColorFormatter extends BaseFormatter {
+
+    public HslaColorFormatter() {
+      super("hslaColor", false);
+    }
+
+    @Override
+    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
+      Variable var = variables.first();
+      JsonNode node = var.node();
+
+      int hue = node.path("hue").asInt();
+      double saturation = node.path("saturation").asDouble();
+      double lightness = node.path("lightness").asDouble();
+      double alpha = node.path("alpha").asDouble();
+      if (saturation <= 1) {
+        saturation *= 100;
+      }
+      if (lightness <= 1) {
+        lightness *= 100;
+      }
+
+      DecimalFormat format = new DecimalFormat("0.#");
+
+      StringBuilder buf = new StringBuilder();
+      buf.append("hsla(");
+      buf.append(hue);
+      buf.append(", ");
+      buf.append(format.format(saturation));
+      buf.append("%, ");
+      buf.append(format.format(lightness));
+      buf.append("%, ");
+      buf.append(format.format(alpha));
+      buf.append(")");
+      var.set(buf);
     }
   };
 

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -245,14 +245,18 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
     result = eval(ctx);
     assertEquals(result, "hsl(110, 90%, 100%)");
 
+    template = "{missing-hsla|website-color}";
+    String missingHslaJson = "{\"missing-hsla\": {\"saturation\": 0.2, \"lightness\": 0, \"alpha\": 0.1}}";
+    code = compiler().compile(template).code();
+    ctx = compiler().newExecutor().code(code).json(missingHslaJson).execute();
+    result = eval(ctx);
+    assertEquals(result, "Missing an H/S/L value.");
+
     template = "{invalid-hsla|website-color}";
     String invalidHslaJson = "{\"invalid-hsla\": {\"hue\": 400, \"saturation\": -0.3, \"lightness\": 5, \"alpha\": 3}}";
     code = compiler().compile(template).code();
     ctx = compiler().newExecutor().code(code).json(invalidHslaJson).execute();
     result = eval(ctx);
-    assertEquals(result, "Hue value is out of bounds. It should be between 0 and 360. "
-        + "Saturation value is out of bounds. It should be between 0 and 1. "
-        + "Lightness value is out of bounds. It should be between 0 and 1. "
-        + "Alpha value is out of bounds. It should be between 0 and 1.");
+    assertEquals(result, "Hue out of bounds. Saturation out of bounds. Lightness out of bounds. Alpha out of bounds.");
   }
 }

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -229,4 +229,30 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
     assertFormatter(HEIGHT, json, "200");
   }
 
+  @Test
+  public void testWebsiteColor() throws CodeException {
+    String template = "{valid-hsla|website-color}";
+    String validHslaJson = "{\"valid-hsla\": {\"hue\": 200, \"saturation\": 0.3, \"lightness\": 0.5, \"alpha\": 0.9}}";
+    Instruction code = compiler().compile(template).code();
+    Context ctx = compiler().newExecutor().code(code).json(validHslaJson).execute();
+    String result = eval(ctx);
+    assertEquals(result, "hsla(200, 30%, 50%, 0.9)");
+
+    template = "{valid-hsl|website-color}";
+    String validHslJson = "{\"valid-hsl\": {\"hue\": 110, \"saturation\": 0.9, \"lightness\": 1}}";
+    code = compiler().compile(template).code();
+    ctx = compiler().newExecutor().code(code).json(validHslJson).execute();
+    result = eval(ctx);
+    assertEquals(result, "hsl(110, 90%, 100%)");
+
+    template = "{invalid-hsla|website-color}";
+    String invalidHslaJson = "{\"invalid-hsla\": {\"hue\": 400, \"saturation\": -0.3, \"lightness\": 5, \"alpha\": 3}}";
+    code = compiler().compile(template).code();
+    ctx = compiler().newExecutor().code(code).json(invalidHslaJson).execute();
+    result = eval(ctx);
+    assertEquals(result, "Hue value is out of bounds. It should be between 0 and 360. "
+        + "Saturation value is out of bounds. It should be between 0 and 1. "
+        + "Lightness value is out of bounds. It should be between 0 and 1. "
+        + "Alpha value is out of bounds. It should be between 0 and 1.");
+  }
 }

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -36,6 +36,7 @@ import com.squarespace.template.plugins.platform.ContentFormatters.ResizedWidthF
 import com.squarespace.template.plugins.platform.ContentFormatters.SqspThumbForHeightFormatter;
 import com.squarespace.template.plugins.platform.ContentFormatters.SqspThumbForWidthFormatter;
 import com.squarespace.template.plugins.platform.ContentFormatters.TimesinceFormatter;
+import com.squarespace.template.plugins.platform.ContentFormatters.WebsiteColorFormatter;
 import com.squarespace.template.plugins.platform.ContentFormatters.WidthFormatter;
 
 
@@ -59,6 +60,8 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
   private static final Formatter TIMESINCE = new TimesinceFormatter();
 
   private static final Formatter WIDTH = new WidthFormatter();
+
+  private static final Formatter WEBSITE_COLOR = new WebsiteColorFormatter();
 
   private final TestSuiteRunner runner = new TestSuiteRunner(compiler(), ContentFormattersTest.class);
 
@@ -231,32 +234,17 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
 
   @Test
   public void testWebsiteColor() throws CodeException {
-    String template = "{valid-hsla|website-color}";
-    String validHslaJson = "{\"valid-hsla\": {\"hue\": 200, \"saturation\": 0.3, \"lightness\": 0.5, \"alpha\": 0.9}}";
-    Instruction code = compiler().compile(template).code();
-    Context ctx = compiler().newExecutor().code(code).json(validHslaJson).execute();
-    String result = eval(ctx);
-    assertEquals(result, "hsla(200, 30%, 50%, 0.9)");
+    String validHslaJson = "{\"hue\": 200, \"saturation\": 0.3, \"lightness\": 0.5, \"alpha\": 0.9}";
+    assertFormatter(WEBSITE_COLOR, validHslaJson, "hsla(200, 30%, 50%, 0.9)");
 
-    template = "{valid-hsl|website-color}";
-    String validHslJson = "{\"valid-hsl\": {\"hue\": 110, \"saturation\": 0.9, \"lightness\": 1}}";
-    code = compiler().compile(template).code();
-    ctx = compiler().newExecutor().code(code).json(validHslJson).execute();
-    result = eval(ctx);
-    assertEquals(result, "hsl(110, 90%, 100%)");
+    String validHslJson = "{\"hue\": 110, \"saturation\": 0.9, \"lightness\": 1}";
+    assertFormatter(WEBSITE_COLOR, validHslJson, "hsl(110, 90%, 100%)");
 
-    template = "{missing-hsla|website-color}";
-    String missingHslaJson = "{\"missing-hsla\": {\"saturation\": 0.2, \"lightness\": 0, \"alpha\": 0.1}}";
-    code = compiler().compile(template).code();
-    ctx = compiler().newExecutor().code(code).json(missingHslaJson).execute();
-    result = eval(ctx);
-    assertEquals(result, "Missing an H/S/L value.");
+    String missingHslaJson = "{\"saturation\": 0.9, \"lightness\": 1}";
+    assertFormatter(WEBSITE_COLOR, missingHslaJson, "Missing an H/S/L value.");
 
-    template = "{invalid-hsla|website-color}";
-    String invalidHslaJson = "{\"invalid-hsla\": {\"hue\": 400, \"saturation\": -0.3, \"lightness\": 5, \"alpha\": 3}}";
-    code = compiler().compile(template).code();
-    ctx = compiler().newExecutor().code(code).json(invalidHslaJson).execute();
-    result = eval(ctx);
-    assertEquals(result, "Hue out of bounds. Saturation out of bounds. Lightness out of bounds. Alpha out of bounds.");
+    String invalidHslaJson = "{\"hue\": 400, \"saturation\": -0.3, \"lightness\": 5, \"alpha\": 3}";
+    assertFormatter(WEBSITE_COLOR, invalidHslaJson, "Hue out of bounds. Saturation out of bounds. "
+        + "Lightness out of bounds. Alpha out of bounds.");
   }
 }


### PR DESCRIPTION
currently, the lightness and saturation values of the HSLA model are stored as a decimal value between 0-1.  however, CSS needs these values as a percentage (0-100).  this formatter takes in an HSLA model from `{ "hue": 360, "saturation": 1, "lightness": 1, "alpha": 0.5 })` and outputs `hsla(360, 100%, 100%, 0.5)`

to test this, i had the following code in a JSON-T file:
```
** without formatter: {customColor.values.hue}, {customColor.values.saturation}, {customColor.values.lightness}, {customColor.values.alpha};
** with formatter: {customColor.values|hslaColor};
```

it outputted the following:
![Screen Shot 2022-09-23 at 4 36 43 PM](https://user-images.githubusercontent.com/59620794/192329960-8c33fff6-0f50-4b09-bbb3-fbaa3f9ade62.png)

UPDATE:
here is a screenshot that shows the formatter handling HSL vs. HSLA.
![Screen Shot 2022-09-26 at 2 40 51 PM](https://user-images.githubusercontent.com/59620794/192357043-3d148afa-bc29-4cdc-ae46-96b666b09a25.png)

here is a screenshot of an error message for an HSLA that has all out of bounds values:
![Screen Shot 2022-09-26 at 2 49 06 PM](https://user-images.githubusercontent.com/59620794/192357147-40145546-5e97-4458-b0fc-7943b4df8d0e.png)


