### PR TITLE
[CMS-45394] - update website-color formatter to round to nearest two decimal points

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/ContentFormatters.java
@@ -329,7 +329,7 @@ public class ContentFormatters implements FormatterRegistry {
       super("website-color", false);
     }
 
-    private final DecimalFormat format = new DecimalFormat("0.#");
+    private final DecimalFormat format = new DecimalFormat("0.##");
 
     @Override
     public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {

--- a/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/ContentFormattersTest.java
@@ -246,5 +246,8 @@ public class ContentFormattersTest extends PlatformUnitTestBase {
     String invalidHslaJson = "{\"hue\": 400, \"saturation\": -0.3, \"lightness\": 5, \"alpha\": 3}";
     assertFormatter(WEBSITE_COLOR, invalidHslaJson, "Hue out of bounds. Saturation out of bounds. "
         + "Lightness out of bounds. Alpha out of bounds.");
+
+    String validHslaJsonDecimals = "{\"hue\": 0.956, \"saturation\": 0.9554, \"lightness\": 0.9567, \"alpha\": 0.555}";
+    assertFormatter(WEBSITE_COLOR, validHslaJsonDecimals, "hsla(0.96, 95.54%, 95.67%, 0.56)");
   }
 }


### PR DESCRIPTION
the website-color formatter originally rounded values to one decimal point. this PR updates it to two decimal points.