### PR TITLE
Support multiple named locales

### DIFF
--- a/core/src/main/java/com/squarespace/template/CompilerExecutor.java
+++ b/core/src/main/java/com/squarespace/template/CompilerExecutor.java
@@ -16,10 +16,13 @@
 
 package com.squarespace.template;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.squarespace.cldrengine.api.Pair;
 import com.squarespace.template.expr.ExprOptions;
 
 
@@ -37,6 +40,7 @@ public class CompilerExecutor {
   private ObjectNode injectablesMap;
   private StringBuilder buffer;
   private Locale locale;
+  private List<Pair<String, Locale>> locales;
   private LoggingHook loggingHook;
   private CodeLimiter codeLimiter;
   private boolean safeExecution;
@@ -84,6 +88,11 @@ public class CompilerExecutor {
     }
     if (locale != null) {
       ctx.javaLocale(locale);
+    }
+    if (locales != null) {
+      for (Pair<String, Locale> entry : locales) {
+        ctx.localeManager().addLocale(entry._1, entry._2);
+      }
     }
     if (now != null) {
       ctx.now(now);
@@ -182,6 +191,17 @@ public class CompilerExecutor {
    */
   public CompilerExecutor locale(Locale locale) {
     this.locale = locale;
+    return this;
+  }
+
+  /**
+   * Additional named locales that can be selected by formatters.
+   */
+  public CompilerExecutor locale(String name, Locale locale) {
+    if (this.locales == null) {
+      this.locales = new ArrayList<>(2);
+    }
+    this.locales.add(Pair.of(name, locale));
     return this;
   }
 

--- a/core/src/main/java/com/squarespace/template/Context.java
+++ b/core/src/main/java/com/squarespace/template/Context.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.squarespace.cldrengine.CLDR;
-import com.squarespace.cldrengine.api.CLocale;
 import com.squarespace.template.expr.ExprOptions;
 
 
@@ -51,11 +50,7 @@ public class Context {
 
   private static final String META_RIGHT = "}";
 
-  private Locale javaLocale;
-
-  private CLDR cldrengine;
-
-  private MessageFormats messageformats;
+  private LocaleManager localeManager;
 
   private Compiler compiler;
 
@@ -111,7 +106,7 @@ public class Context {
   public Context(JsonNode node, StringBuilder buf, Locale locale) {
     this.currentFrame = new Frame(null, node == null ? MissingNode.getInstance() : node);
     this.buf = buf == null ? new StringBuilder() : buf;
-    this.javaLocale = locale == null ? Locale.US : locale;
+    this.localeManager = new LocaleManager(locale == null ? Locale.US : locale);
   }
 
   public boolean safeExecutionEnabled() {
@@ -136,12 +131,28 @@ public class Context {
     this.exprOptions = options;
   }
 
+  public LocaleManager localeManager() {
+    return this.localeManager;
+  }
+
   public Locale javaLocale() {
-    return javaLocale;
+    return this.localeManager.get().locale();
   }
 
   public void javaLocale(Locale locale) {
-    this.javaLocale = locale;
+    this.localeManager.setLocale(locale);
+  }
+
+  public CLDR cldr() {
+    return this.localeManager.get().cldr();
+  }
+
+  public MessageFormats messageFormatter() {
+    return this.localeManager.get().formatter();
+  }
+
+  public void addLocale(String name, Locale locale) {
+    this.localeManager.addLocale(name, locale);
   }
 
   public void now(Long value) {
@@ -150,41 +161,6 @@ public class Context {
 
   public Long now() {
     return now;
-  }
-
-//  public void cldrLocale(CLDR.Locale locale) {
-//    this.cldrLocale = locale;
-//  }
-//
-//  public CLDR.Locale cldrLocale() {
-//    return cldrLocale;
-//  }
-
-  public MessageFormats messageFormatter() {
-    if (this.messageformats == null) {
-      this.messageformats = new MessageFormats(this.cldr());
-    }
-    return this.messageformats;
-  }
-
-  public CLDR cldr() {
-    if (cldrengine == null) {
-      String tag = javaLocale != null ? this.javaLocale.toLanguageTag() : "en-US";
-      this.cldrengine = com.squarespace.cldrengine.CLDR.get(tag);
-    }
-    return cldrengine;
-  }
-
-  public void cldrengine(CLDR cldr) {
-    this.cldrengine = cldr;
-  }
-
-  public void cldrengine(String id) {
-    this.cldrengine = CLDR.get(id);
-  }
-
-  public void cldrengine(CLocale locale) {
-    this.cldrengine = CLDR.get(locale);
   }
 
   /**

--- a/core/src/main/java/com/squarespace/template/LocaleManager.java
+++ b/core/src/main/java/com/squarespace/template/LocaleManager.java
@@ -1,0 +1,66 @@
+package com.squarespace.template;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import com.squarespace.cldrengine.CLDR;
+
+public class LocaleManager {
+
+  public static final String DEFAULT = "main";
+  private final Map<String, Entry> entries = new HashMap<>(2);
+
+  public LocaleManager() {
+    this.entries.put(DEFAULT, new Entry(Locale.US));
+  }
+
+  public LocaleManager(Locale locale) {
+    this.entries.put(DEFAULT, new Entry(locale));
+  }
+
+  public void setLocale(Locale locale) {
+    this.entries.put(DEFAULT, new Entry(locale));
+  }
+
+  public void addLocale(String name, Locale locale) {
+    this.entries.put(name, new Entry(locale));
+  }
+
+  public Entry get() {
+    return this.entries.get(DEFAULT);
+  }
+
+  public Entry get(String name) {
+    Entry entry = this.entries.get(name);
+    return entry == null ? this.entries.get(DEFAULT) : entry;
+  }
+
+  public static class Entry {
+
+    private final Locale locale;
+    private final CLDR cldr;
+    private MessageFormats formatter;
+
+    public Entry(Locale locale) {
+      this.locale = locale;
+      this.cldr = CLDR.get(locale);
+    }
+
+    public Locale locale() {
+      return this.locale;
+    }
+
+    public CLDR cldr() {
+      return this.cldr;
+    }
+
+    public MessageFormats formatter() {
+      if (this.formatter == null) {
+        this.formatter = new MessageFormats(this.cldr);
+      }
+      return this.formatter;
+    }
+  }
+
+}

--- a/core/src/main/java/com/squarespace/template/MessageFormats.java
+++ b/core/src/main/java/com/squarespace/template/MessageFormats.java
@@ -104,8 +104,8 @@ public class MessageFormats {
     Decimal value = this.converter.asDecimal(decimalValue);
     String code = this.converter.asString(currencyCode);
     CurrencyType currency = CurrencyType.fromString(code);
-    CurrencyFormatOptions opts = OptionParsers.currency(options);
-    return cldr.Numbers.formatCurrency(value, currency, opts);
+    Options<CurrencyFormatOptions> opts = OptionParsers.currency(options);
+    return cldr.Numbers.formatCurrency(value, currency, opts.inner());
   }
 
   /**
@@ -121,8 +121,8 @@ public class MessageFormats {
     }
     long epoch = node.asLong();
     CalendarDate date = cldr.Calendars.toGregorianDate(epoch, zoneId);
-    DateFormatOptions opts = OptionParsers.datetime(options);
-    return cldr.Calendars.formatDate(date, opts);
+    Options<DateFormatOptions> opts = OptionParsers.datetime(options);
+    return cldr.Calendars.formatDate(date, opts.inner());
   }
 
   /**
@@ -137,8 +137,8 @@ public class MessageFormats {
       return "";
     }
     Decimal value = this.converter.asDecimal(node);
-    DecimalFormatOptions opts = OptionParsers.decimal(options);
-    return cldr.Numbers.formatDecimal(value, opts);
+    Options<DecimalFormatOptions> opts = OptionParsers.decimal(options);
+    return cldr.Numbers.formatDecimal(value, opts.inner());
   }
 
   /**
@@ -155,8 +155,8 @@ public class MessageFormats {
     }
     CalendarDate start = cldr.Calendars.toGregorianDate(v1.asLong(0), zoneId);
     CalendarDate end = cldr.Calendars.toGregorianDate(v2.asLong(0), zoneId);
-    DateIntervalFormatOptions opts = OptionParsers.interval(options);
-    return cldr.Calendars.formatDateInterval(start, end, opts);
+    Options<DateIntervalFormatOptions> opts = OptionParsers.interval(options);
+    return cldr.Calendars.formatDateInterval(start, end, opts.inner());
   }
 
   private static class ArgConverter extends DefaultMessageArgConverter {

--- a/core/src/main/java/com/squarespace/template/Options.java
+++ b/core/src/main/java/com/squarespace/template/Options.java
@@ -1,0 +1,29 @@
+package com.squarespace.template;
+
+
+public class Options<T> {
+
+  private String localeName;
+  private T inner;
+
+  public Options(String localeName, T inner) {
+    this.localeName = localeName;
+    this.inner = inner;
+  }
+
+  public String localeName() {
+    return this.localeName;
+  }
+
+  public void localeName(String name) {
+    this.localeName = name;
+  }
+
+  public T inner() {
+    return this.inner;
+  }
+
+  public void inner(T inner) {
+    this.inner = inner;
+  }
+}

--- a/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DateTimeFormatter.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DateTimeFormatter.java
@@ -22,6 +22,7 @@ import com.squarespace.template.BaseFormatter;
 import com.squarespace.template.CodeExecuteException;
 import com.squarespace.template.Context;
 import com.squarespace.template.OptionParsers;
+import com.squarespace.template.Options;
 import com.squarespace.template.Variable;
 import com.squarespace.template.Variables;
 import com.squarespace.template.plugins.PluginDateUtils;
@@ -38,7 +39,7 @@ public class DateTimeFormatter extends BaseFormatter {
 
   @Override
   public void validateArgs(Arguments args) throws ArgumentsException {
-    DateFormatOptions options = OptionParsers.datetime(args);
+    Options<DateFormatOptions> options = OptionParsers.datetime(args);
     args.setOpaque(options);
   }
 
@@ -47,10 +48,11 @@ public class DateTimeFormatter extends BaseFormatter {
     Variable var = variables.first();
     long epoch = var.node().asLong();
     String zoneId = PluginDateUtils.getTimeZoneNameFromContext(ctx);
-    CLDR cldr = ctx.cldr();
-    DateFormatOptions options = (DateFormatOptions) args.getOpaque();
+    @SuppressWarnings("unchecked")
+    Options<DateFormatOptions> options = (Options<DateFormatOptions>) args.getOpaque();
+    CLDR cldr = ctx.localeManager().get(options.localeName()).cldr();
     CalendarDate date = cldr.Calendars.toGregorianDate(epoch, zoneId);
-    String result = cldr.Calendars.formatDate(date, options);
+    String result = cldr.Calendars.formatDate(date, options.inner());
     var.set(result);
   }
 

--- a/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DateTimeIntervalFormatter.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DateTimeIntervalFormatter.java
@@ -25,6 +25,7 @@ import com.squarespace.template.BaseFormatter;
 import com.squarespace.template.CodeExecuteException;
 import com.squarespace.template.Context;
 import com.squarespace.template.OptionParsers;
+import com.squarespace.template.Options;
 import com.squarespace.template.Variable;
 import com.squarespace.template.Variables;
 import com.squarespace.template.plugins.PluginDateUtils;
@@ -41,7 +42,7 @@ public class DateTimeIntervalFormatter extends BaseFormatter {
 
   @Override
   public void validateArgs(Arguments args) throws ArgumentsException {
-    DateIntervalFormatOptions options = OptionParsers.interval(args);
+    Options<DateIntervalFormatOptions> options = OptionParsers.interval(args);
     args.setOpaque(options);
   }
 
@@ -55,12 +56,13 @@ public class DateTimeIntervalFormatter extends BaseFormatter {
     Variable v1 = variables.get(0);
     Variable v2 = variables.get(1);
 
-    CLDR cldr = ctx.cldr();
+    @SuppressWarnings("unchecked")
+    Options<DateIntervalFormatOptions> options = (Options<DateIntervalFormatOptions>) args.getOpaque();
+    CLDR cldr = ctx.localeManager().get(options.localeName()).cldr();
     String zoneId = PluginDateUtils.getTimeZoneNameFromContext(ctx);
     CalendarDate start = cldr.Calendars.toGregorianDate(v1.node().asLong(0), zoneId);
     CalendarDate end = cldr.Calendars.toGregorianDate(v2.node().asLong(0), zoneId);
-    DateIntervalFormatOptions options = (DateIntervalFormatOptions) args.getOpaque();
-    String result = cldr.Calendars.formatDateInterval(start, end, options);
+    String result = cldr.Calendars.formatDateInterval(start, end, options.inner());
     v1.set(result);
   }
 

--- a/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DecimalFormatter.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/i18n/DecimalFormatter.java
@@ -25,6 +25,7 @@ import com.squarespace.template.CodeExecuteException;
 import com.squarespace.template.Context;
 import com.squarespace.template.GeneralUtils;
 import com.squarespace.template.OptionParsers;
+import com.squarespace.template.Options;
 import com.squarespace.template.Variable;
 import com.squarespace.template.Variables;
 
@@ -40,7 +41,7 @@ public class DecimalFormatter extends BaseFormatter {
 
   @Override
   public void validateArgs(Arguments args) throws ArgumentsException {
-    DecimalFormatOptions opts = OptionParsers.decimal(args);
+    Options<DecimalFormatOptions> opts = OptionParsers.decimal(args);
     args.setOpaque(opts);
   }
 
@@ -53,9 +54,10 @@ public class DecimalFormatter extends BaseFormatter {
       return;
     }
 
-    CLDR cldr = ctx.cldr();
-    DecimalFormatOptions opts = (DecimalFormatOptions) args.getOpaque();
-    String result = cldr.Numbers.formatDecimal(number, opts);
+    @SuppressWarnings("unchecked")
+    Options<DecimalFormatOptions> opts = (Options<DecimalFormatOptions>) args.getOpaque();
+    CLDR cldr = ctx.localeManager().get(opts.localeName()).cldr();
+    String result = cldr.Numbers.formatDecimal(number, opts.inner());
     var.set(result);
   }
 

--- a/core/src/main/java/com/squarespace/template/plugins/platform/i18n/MoneyFormatter.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/i18n/MoneyFormatter.java
@@ -27,6 +27,7 @@ import com.squarespace.template.CodeExecuteException;
 import com.squarespace.template.Context;
 import com.squarespace.template.GeneralUtils;
 import com.squarespace.template.OptionParsers;
+import com.squarespace.template.Options;
 import com.squarespace.template.Variable;
 import com.squarespace.template.Variables;
 import com.squarespace.template.plugins.platform.CommerceUtils;
@@ -45,7 +46,7 @@ public class MoneyFormatter extends BaseFormatter {
 
   @Override
   public void validateArgs(Arguments args) throws ArgumentsException {
-    CurrencyFormatOptions opts = OptionParsers.currency(args);
+    Options<CurrencyFormatOptions> opts = OptionParsers.currency(args);
     args.setOpaque(opts);
   }
 
@@ -70,12 +71,13 @@ public class MoneyFormatter extends BaseFormatter {
       }
     }
 
-    CLDR cldr = ctx.cldr();
+    @SuppressWarnings("unchecked")
+    Options<CurrencyFormatOptions> opts = (Options<CurrencyFormatOptions>) args.getOpaque();
+    CLDR cldr = ctx.localeManager().get(opts.localeName()).cldr();
     String code = currencyNode.asText();
     Decimal decimal = GeneralUtils.nodeToDecimal(decimalValue);
     CurrencyType currency = CurrencyType.fromString(code);
-    CurrencyFormatOptions opts = (CurrencyFormatOptions) args.getOpaque();
-    String result = cldr.Numbers.formatCurrency(decimal, currency, opts);
+    String result = cldr.Numbers.formatCurrency(decimal, currency, opts.inner());
     var.set(result);
   }
 

--- a/core/src/main/java/com/squarespace/template/plugins/platform/i18n/RelativeTimeFormatter.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/i18n/RelativeTimeFormatter.java
@@ -4,10 +4,12 @@ import com.squarespace.cldrengine.CLDR;
 import com.squarespace.cldrengine.api.CalendarDate;
 import com.squarespace.cldrengine.api.RelativeTimeFormatOptions;
 import com.squarespace.template.Arguments;
+import com.squarespace.template.ArgumentsException;
 import com.squarespace.template.BaseFormatter;
 import com.squarespace.template.CodeExecuteException;
 import com.squarespace.template.Context;
 import com.squarespace.template.OptionParsers;
+import com.squarespace.template.Options;
 import com.squarespace.template.Variable;
 import com.squarespace.template.Variables;
 
@@ -15,6 +17,12 @@ public class RelativeTimeFormatter extends BaseFormatter {
 
   public RelativeTimeFormatter() {
     super("relative-time", false);
+  }
+
+  @Override
+  public void validateArgs(Arguments args) throws ArgumentsException {
+    Options<RelativeTimeFormatOptions> options = OptionParsers.relativetime(args);
+    args.setOpaque(options);
   }
 
   @Override
@@ -29,11 +37,12 @@ public class RelativeTimeFormatter extends BaseFormatter {
       e = variables.get(1).node().asLong();
     }
 
-    CLDR cldr = ctx.cldr();
+    @SuppressWarnings("unchecked")
+    Options<RelativeTimeFormatOptions> opts = (Options<RelativeTimeFormatOptions>)args.getOpaque();
+    CLDR cldr = ctx.localeManager().get(opts.localeName()).cldr();
     CalendarDate start = cldr.Calendars.toGregorianDate(s, "UTC");
     CalendarDate end = cldr.Calendars.toGregorianDate(e, "UTC");
-    RelativeTimeFormatOptions opts = OptionParsers.relativetime(args);
-    String res = cldr.Calendars.formatRelativeTime(start, end, opts);
+    String res = cldr.Calendars.formatRelativeTime(start, end, opts.inner());
     v1.set(res);
   }
 }

--- a/core/src/test/java/com/squarespace/template/TestCaseParser.java
+++ b/core/src/test/java/com/squarespace/template/TestCaseParser.java
@@ -157,11 +157,21 @@ public class TestCaseParser extends UnitTestBase {
           executor.injectablesMap(injectMap);
         }
 
-
         String locale = properties.getProperty("locale");
         if (locale != null) {
-          java.util.Locale javaLocale = java.util.Locale.forLanguageTag(locale);
-          executor.locale(javaLocale);
+          // Supports named locales of the form "name:tag".
+          String[] parts = locale.split("\\s+");
+          for (String part : parts) {
+            String name = LocaleManager.DEFAULT;
+            String value = part;
+            int i = part.indexOf(':');
+            if (i != -1) {
+               name = part.substring(0, i);
+               value = part.substring(i + 1);
+            }
+            java.util.Locale javaLocale = java.util.Locale.forLanguageTag(value);
+            executor.locale(name, javaLocale);
+          }
         }
 
         Context ctx = executor.execute();

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/DateTimeIntervalFormatterTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/DateTimeIntervalFormatterTest.java
@@ -28,7 +28,10 @@ public class DateTimeIntervalFormatterTest extends PlatformUnitTestBase {
 
   @Test
   public void testInterval() {
-    runner.run("f-datetime-interval-1.html");
+    runner.run(
+        "f-datetime-interval-1.html",
+        "f-datetime-interval-multi-locale-1.html"
+    );
   }
 
 }

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/DecimalFormatterTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/DecimalFormatterTest.java
@@ -56,7 +56,8 @@ public class DecimalFormatterTest extends PlatformUnitTestBase {
     runner.run(
         "f-decimal-1.html",
         // f-decimal-2 defunct
-        "f-decimal-3.html"
+        "f-decimal-3.html",
+        "f-decimal-multi-locale-1.html"
     );
   }
 

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MessageFormatterTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MessageFormatterTest.java
@@ -29,6 +29,7 @@ public class MessageFormatterTest extends PlatformUnitTestBase {
   public void testMessageFormatter() throws Exception {
     runner.run(
         "f-message-named-args.html",
+        "f-message-multi-locale-1.html",
 //        "f-message-units-en-US.html",
 //        "f-message-units-fr-FR.html",
         "f-message-datetime-interval-en-US.html",

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MigrationTests.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MigrationTests.java
@@ -41,7 +41,8 @@ public class MigrationTests  extends PlatformUnitTestBase {
   @Test
   public void testMoney() {
     runner.run(
-        "f-migrate-money-1.html"
+        "f-migrate-money-1.html",
+        "f-migrate-money-multi-locale-1.html"
     );
   }
 }

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MultiLocaleTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/MultiLocaleTest.java
@@ -1,0 +1,18 @@
+package com.squarespace.template.plugins.platform.i18n;
+
+import org.testng.annotations.Test;
+
+import com.squarespace.template.TestSuiteRunner;
+import com.squarespace.template.plugins.platform.PlatformUnitTestBase;
+
+@Test(groups = { "unit" })
+public class MultiLocaleTest extends PlatformUnitTestBase {
+
+  private final TestSuiteRunner runner = new TestSuiteRunner(compiler(), MultiLocaleTest.class);
+
+  @Test
+  public void testMultiLocale() {
+    runner.run("f-datetime-multi-locale-1.html", "f-datetime-multi-locale-2.html");
+  }
+
+}

--- a/core/src/test/java/com/squarespace/template/plugins/platform/i18n/RelativeTimeFormatterTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/i18n/RelativeTimeFormatterTest.java
@@ -27,6 +27,9 @@ public class RelativeTimeFormatterTest extends PlatformUnitTestBase {
 
   @Test
   public void testRelativeTime() {
-    runner.run("f-relative-time-1.html");
+    runner.run(
+      "f-relative-time-1.html",
+      "f-relative-time-multi-locale-1.html"
+    );
   }
 }

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-interval-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-interval-multi-locale-1.html
@@ -1,0 +1,34 @@
+:PROPERTIES
+locale=user:es
+
+:JSON
+{
+	"website": {"timeZone": "America/Los_Angeles"},
+	"dates": [
+		{"start": 1509647217000, "end": 1510641417000},
+		{"start": 1502298000000, "end": 1502305200000}
+	]
+}
+
+
+:TEMPLATE
+{.repeated section dates}
+{start, end|datetime-interval}
+{start, end|datetime-interval EyMMMd}
+
+{start, end|datetime-interval locale:user}
+{start, end|datetime-interval EyMMMd locale:user}
+{.end}
+
+:OUTPUT
+Nov 2 – 13, 2017
+Thu, Nov 2 – Mon, Nov 13, 2017
+
+2–13 nov. 2017
+jue., 2 nov. – lun., 13 nov. 2017
+
+10:00 AM – 12:00 PM
+Wed, Aug 9, 2017
+
+10:00 a. m. – 12:00 p. m.
+mié., 9 ago. 2017

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-multi-locale-1.html
@@ -1,0 +1,18 @@
+:PROPERTIES
+locale=en user:es other:de
+
+:JSON
+{
+	"t": 1581361671000
+}
+
+:TEMPLATE
+{t|datetime}
+{t|datetime locale:user}
+{t|datetime locale:other}
+
+:OUTPUT
+February 10, 2020
+10 de febrero de 2020
+10. Februar 2020
+

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-multi-locale-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-datetime-multi-locale-2.html
@@ -1,0 +1,16 @@
+:PROPERTIES
+locale=user:es
+
+:JSON
+{
+	"t": 1581361671000
+}
+
+:TEMPLATE
+{t|datetime}
+{t|datetime locale:user}
+
+:OUTPUT
+February 10, 2020
+10 de febrero de 2020
+

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-decimal-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-decimal-multi-locale-1.html
@@ -1,0 +1,28 @@
+:PROPERTIES
+locale=en user:es other:ko
+
+:JSON
+{
+  "n": "123456789.12345"
+}
+
+:TEMPLATE
+{n|decimal group}
+{n|decimal style:short group}
+
+{n|decimal locale:user group}
+{n|decimal locale:user style:short group}
+
+{n|decimal locale:other group}
+{n|decimal locale:other style:short group}
+
+
+:OUTPUT
+123,456,789.123
+123M
+
+123.456.789,123
+123 M
+
+123,456,789.123
+1.2억

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-message-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-message-multi-locale-1.html
@@ -1,0 +1,20 @@
+:PROPERTIES
+locale=user:es other:ko
+
+:JSON
+{
+  "messages": {
+    "transfer": "Transmission will occur at {t datetime time:long}"
+  },
+  "timestamp": 12345657890
+}
+
+:TEMPLATE
+{messages.transfer|message t:timestamp}
+{messages.transfer|message locale:user t:timestamp}
+{messages.transfer|message locale:other t:timestamp}
+
+:OUTPUT
+Transmission will occur at 5:20:57 PM EDT
+Transmission will occur at 17:20:57 GMT-4
+Transmission will occur at PM 5시 20분 57초 GMT-4

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-migrate-money-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-migrate-money-multi-locale-1.html
@@ -1,0 +1,73 @@
+:PROPERTIES
+locale=en user:es other:ko
+
+:JSON
+{
+	"amounts": [
+	  {
+	    "currencyCode": "USD",
+	    "decimalValue": 123456
+	  },
+	  {
+	    "currencyCode": "USD",
+	    "decimalValue": -123456
+	  },	  {
+	    "currencyCode": "AUD",
+	    "decimalValue": 123456
+	  },
+	  {
+	  	"currencyCode": "EUR",
+	  	"decimalValue": 123456
+	  }
+	]
+}
+
+:TEMPLATE
+{.repeated section amounts}
+{@|money}
+{@|money style:accounting}
+
+{@|money locale:user}
+{@|money style:accounting locale:user}
+
+{@|money locale:other}
+{@|money style:accounting locale:other}
+{.end}
+
+:OUTPUT
+$123,456.00
+$123,456.00
+
+123.456,00 US$
+123.456,00 US$
+
+US$123,456.00
+US$123,456.00
+
+-$123,456.00
+($123,456.00)
+
+-123.456,00 US$
+-123.456,00 US$
+
+-US$123,456.00
+(US$123,456.00)
+
+A$123,456.00
+A$123,456.00
+
+123.456,00 AUD
+123.456,00 AUD
+
+AU$123,456.00
+AU$123,456.00
+
+€123,456.00
+€123,456.00
+
+123.456,00 €
+123.456,00 €
+
+€123,456.00
+€123,456.00
+

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-relative-time-multi-locale-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/i18n/f-relative-time-multi-locale-1.html
@@ -1,0 +1,18 @@
+:PROPERTIES
+now=1502298000000
+locale=user:es other:de
+
+:JSON
+{"start": 1509647217000, "end": 1510641417000}
+
+
+
+:TEMPLATE
+{start, end|relative-time}
+{start, end|relative-time locale:user}
+{start, end|relative-time locale:other}
+
+:OUTPUT
+in 2 weeks
+dentro de 2 semanas
+in 2 Wochen


### PR DESCRIPTION
Extends the compiler to support multiple named locales that can be selected by formatters.

In this example this assumes the compiler has been configured with a default locale and one named locale `"user"` set to `es`:
```
{t|datetime}
{t|datetime locale:user}
```
output:
```
February 10, 2020
10 de febrero de 2020
```
