### PR TITLE
[COM-26547]: added secondary button class to radio label, role as button and tabIndex

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/variants-select.html
@@ -15,7 +15,7 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="{name|htmltag}">{.repeated section values}
       <input type="radio" class="variant-radiobtn" value="{@|htmltag}" name="variant-option-{name|htmltag}" id="variant-option-{name|htmltag}-{@|htmltag}"/>
-      <label for="variant-option-{name|htmltag}-{@|htmltag}">{@|htmltag}</label>{.end}
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-{name|htmltag}-{@|htmltag}">{@|htmltag}</label>{.end}
     </div>
     </div>{.end}
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-product-checkout-1.html
@@ -27,9 +27,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
-      <label for="variant-option-color-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
-      <label for="variant-option-color-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-red">red</label>
     </div>
     </div>
     <div class="variant-option">
@@ -42,9 +42,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-1.html
@@ -27,9 +27,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
-      <label for="variant-option-color-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
-      <label for="variant-option-color-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-red">red</label>
     </div>
     </div>
     <div class="variant-option">
@@ -42,9 +42,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-2.html
@@ -27,9 +27,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
     <div class="variant-option">
@@ -42,9 +42,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
-      <label for="variant-option-color-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
-      <label for="variant-option-color-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-red">red</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-4.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-4.html
@@ -31,9 +31,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
     <div class="variant-option">
@@ -46,9 +46,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
-      <label for="variant-option-color-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
-      <label for="variant-option-color-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-red">red</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-5.html
@@ -31,9 +31,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
     <div class="variant-option">
@@ -46,9 +46,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color&amp;hue">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color&amp;hue" id="variant-option-color&amp;hue-blue"/>
-      <label for="variant-option-color&amp;hue-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color&amp;hue-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color&amp;hue" id="variant-option-color&amp;hue-red"/>
-      <label for="variant-option-color&amp;hue-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color&amp;hue-red">red</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-6.html
@@ -32,9 +32,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="Value">
       <input type="radio" class="variant-radiobtn" value="25" name="variant-option-Value" id="variant-option-Value-25"/>
-      <label for="variant-option-Value-25">25</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-Value-25">25</label>
       <input type="radio" class="variant-radiobtn" value="50" name="variant-option-Value" id="variant-option-Value-50"/>
-      <label for="variant-option-Value-50">50</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-Value-50">50</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-7.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-7.html
@@ -32,9 +32,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="Color">
       <input type="radio" class="variant-radiobtn" value="Blue" name="variant-option-Color" id="variant-option-Color-Blue"/>
-      <label for="variant-option-Color-Blue">Blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-Color-Blue">Blue</label>
       <input type="radio" class="variant-radiobtn" value="Pink" name="variant-option-Color" id="variant-option-Color-Pink"/>
-      <label for="variant-option-Color-Pink">Pink</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-Color-Pink">Pink</label>
     </div>
     </div>
   </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-variants-select-subscription.html
@@ -34,9 +34,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="color">
       <input type="radio" class="variant-radiobtn" value="blue" name="variant-option-color" id="variant-option-color-blue"/>
-      <label for="variant-option-color-blue">blue</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-blue">blue</label>
       <input type="radio" class="variant-radiobtn" value="red" name="variant-option-color" id="variant-option-color-red"/>
-      <label for="variant-option-color-red">red</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-color-red">red</label>
     </div>
     </div>
     <div class="variant-option">
@@ -49,9 +49,9 @@
     </div>
     <div class="variant-radiobtn-wrapper" data-variant-option-name="fit">
       <input type="radio" class="variant-radiobtn" value="loose" name="variant-option-fit" id="variant-option-fit-loose"/>
-      <label for="variant-option-fit-loose">loose</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-loose">loose</label>
       <input type="radio" class="variant-radiobtn" value="slim" name="variant-option-fit" id="variant-option-fit-slim"/>
-      <label for="variant-option-fit-slim">slim</label>
+      <label class="sqs-button-element--secondary" role="button" tabindex="0" for="variant-option-fit-slim">slim</label>
     </div>
     </div>
   </div>


### PR DESCRIPTION
This change is because radio buttons styles are being changed to a button. We also want to apply secondary button styles to radio buttons on the PDP page. See screen shot below: 

![Screen Shot 2023-03-14 at 2 49 45 PM](https://user-images.githubusercontent.com/88727960/225107514-d1ddfd13-b67e-4bf5-914e-c4765aa4ef0d.png)
