### PR TITLE
[DIG-641] key-by formatter

### DIFF
--- a/core/src/main/java/com/squarespace/template/GeneralUtils.java
+++ b/core/src/main/java/com/squarespace/template/GeneralUtils.java
@@ -42,9 +42,11 @@ import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.squarespace.cldrengine.api.Decimal;
+import com.squarespace.template.Constants;
 
 
 /**
@@ -475,4 +477,31 @@ public class GeneralUtils {
     return true;
   }
 
+  public static JsonNode getDeep(JsonNode node, Object[] path) {
+    if (path == null) {
+      return Constants.MISSING_NODE;
+    }
+
+    JsonNode tmp = node;
+
+    for (Object key : path) {
+      // Adapt the argument to the type of node we're accessing
+      if (tmp instanceof ArrayNode && key instanceof Integer) {
+        tmp = tmp.path((int)key);
+      } else if (tmp instanceof ObjectNode) {
+        if (key instanceof Integer) {
+          key = ((Integer)key).toString();
+        }
+        tmp = tmp.path((String)key);
+      } else {
+        tmp = Constants.MISSING_NODE;
+      }
+
+      if (tmp.isMissingNode()) {
+        break;
+      }
+    }
+
+    return tmp;
+  }
 }

--- a/core/src/main/java/com/squarespace/template/GeneralUtils.java
+++ b/core/src/main/java/com/squarespace/template/GeneralUtils.java
@@ -477,7 +477,7 @@ public class GeneralUtils {
     return true;
   }
 
-  public static JsonNode getDeep(JsonNode node, Object[] path) {
+  public static JsonNode getNodeAtPath(JsonNode node, Object[] path) {
     if (path == null) {
       return Constants.MISSING_NODE;
     }

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -82,6 +82,7 @@ public class CoreFormatters implements FormatterRegistry {
     table.add(new IterFormatter());
     table.add(new JsonFormatter());
     table.add(new JsonPrettyFormatter());
+    table.add(new KeyByFormatter());
     table.add(new OutputFormatter());
     table.add(new LookupFormatter());
     table.add(new ModFormatter());
@@ -568,7 +569,7 @@ public class CoreFormatters implements FormatterRegistry {
           JsonNode nodeAtPath = getNodeAtPath(node, splitPath);
 
           if (!nodeAtPath.isMissingNode()) {
-            keyByMap.put(nodeAtPath.toString(), node);
+            keyByMap.put(nodeAtPath.asText(), node);
           }
         }
       }

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -24,7 +24,7 @@ import static com.squarespace.template.GeneralUtils.executeTemplate;
 import static com.squarespace.template.GeneralUtils.isTruthy;
 import static com.squarespace.template.GeneralUtils.jsonPretty;
 import static com.squarespace.template.GeneralUtils.splitVariable;
-import static com.squarespace.template.GeneralUtils.getDeep;
+import static com.squarespace.template.GeneralUtils.getNodeAtPath;
 import static com.squarespace.template.plugins.PluginDateUtils.formatDate;
 import static com.squarespace.template.plugins.PluginUtils.escapeScriptTags;
 
@@ -539,10 +539,13 @@ public class CoreFormatters implements FormatterRegistry {
 
   }
 
+  /**
+   * KEY_BY - maps an array of objects by the value for each at the given path
+   */
   public static class KeyByFormatter extends BaseFormatter {
 
     public KeyByFormatter() {
-      super("key-by", false);
+      super("key-by", true);
     }
 
     @Override
@@ -562,10 +565,10 @@ public class CoreFormatters implements FormatterRegistry {
         Object[] splitPath = splitVariable(path);
 
         for (JsonNode node : nodes) {
-          JsonNode val = getDeep(node, splitPath);
+          JsonNode nodeAtPath = getNodeAtPath(node, splitPath);
 
-          if (!val.isMissingNode()) {
-            keyByMap.put(val.toString(), node);
+          if (!nodeAtPath.isMissingNode()) {
+            keyByMap.put(nodeAtPath.toString(), node);
           }
         }
       }
@@ -702,7 +705,10 @@ public class CoreFormatters implements FormatterRegistry {
       int count = args.count();
       for (int i = 0; i < count; i++) {
         Object[] path = splitVariable(args.get(i));
-        tmp = getDeep(tmp, path);
+        tmp = getNodeAtPath(tmp, path);
+        if (tmp.isMissingNode()) {
+          break;
+        }
       }
       first.set(tmp);
     }

--- a/core/src/test/java/com/squarespace/template/GeneralUtilsTest.java
+++ b/core/src/test/java/com/squarespace/template/GeneralUtilsTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 
@@ -104,5 +105,31 @@ public class GeneralUtilsTest {
     assertEquals(GeneralUtils.ifString(node, "000"), "000");
     node = NullNode.getInstance();
     assertEquals(GeneralUtils.ifString(node, "000"), "000");
+  }
+
+  @Test
+  public void testGetDeep() {
+    ObjectNode arrItem = JsonUtils.createObjectNode();
+    arrItem.put("id", "node-1");
+
+    ArrayNode arr = JsonUtils.createArrayNode();
+    arr.add(arrItem);
+
+    ObjectNode container = JsonUtils.createObjectNode();
+    container.set("arr", arr);
+
+    assertEquals(GeneralUtils.getDeep(container, null), Constants.MISSING_NODE);
+
+    Object[] path = splitVariable("some.0.nonexistent.field");
+    assertEquals(GeneralUtils.getDeep(container, path), Constants.MISSING_NODE);
+
+    path = new Object[0];
+    assertEquals(GeneralUtils.getDeep(container, path), container);
+
+    path = splitVariable("arr");
+    assertEquals(GeneralUtils.getDeep(container, path), arr);
+
+    path = splitVariable("arr.0.id");
+    assertEquals(GeneralUtils.getDeep(container, path).asText(), "node-1");
   }
 }

--- a/core/src/test/java/com/squarespace/template/GeneralUtilsTest.java
+++ b/core/src/test/java/com/squarespace/template/GeneralUtilsTest.java
@@ -108,7 +108,7 @@ public class GeneralUtilsTest {
   }
 
   @Test
-  public void testGetDeep() {
+  public void testGetNodeAtPath() {
     ObjectNode arrItem = JsonUtils.createObjectNode();
     arrItem.put("id", "node-1");
 
@@ -118,18 +118,18 @@ public class GeneralUtilsTest {
     ObjectNode container = JsonUtils.createObjectNode();
     container.set("arr", arr);
 
-    assertEquals(GeneralUtils.getDeep(container, null), Constants.MISSING_NODE);
+    assertEquals(GeneralUtils.getNodeAtPath(container, null), Constants.MISSING_NODE);
 
     Object[] path = splitVariable("some.0.nonexistent.field");
-    assertEquals(GeneralUtils.getDeep(container, path), Constants.MISSING_NODE);
+    assertEquals(GeneralUtils.getNodeAtPath(container, path), Constants.MISSING_NODE);
 
     path = new Object[0];
-    assertEquals(GeneralUtils.getDeep(container, path), container);
+    assertEquals(GeneralUtils.getNodeAtPath(container, path), container);
 
     path = splitVariable("arr");
-    assertEquals(GeneralUtils.getDeep(container, path), arr);
+    assertEquals(GeneralUtils.getNodeAtPath(container, path), arr);
 
     path = splitVariable("arr.0.id");
-    assertEquals(GeneralUtils.getDeep(container, path).asText(), "node-1");
+    assertEquals(GeneralUtils.getNodeAtPath(container, path).asText(), "node-1");
   }
 }

--- a/core/src/test/java/com/squarespace/template/UnitTestBase.java
+++ b/core/src/test/java/com/squarespace/template/UnitTestBase.java
@@ -169,25 +169,36 @@ public class UnitTestBase {
     assertEquals(result, expected);
   }
 
-
   public String format(Formatter impl, String json) throws CodeException {
     return format(impl, EMPTY_ARGUMENTS, json);
   }
 
   public String format(Formatter impl, Arguments args, String json) throws CodeException {
+    return formatRaw(impl, args, json).asText();
+  }
+
+  public JsonNode formatRaw(Formatter impl, Arguments args, String json) throws CodeException {
     Context ctx = new Context(JsonUtils.decode(json));
     impl.validateArgs(args);
     Variables variables = new Variables("var", ctx.node());
     impl.apply(ctx, args, variables);
-    return variables.first().node().asText();
+    return variables.first().node();
   }
 
   public void assertFormatter(Formatter impl, String json, String expected) throws CodeException {
-    assertEquals(format(impl, EMPTY_ARGUMENTS, json), expected);
+    assertFormatter(impl, EMPTY_ARGUMENTS, json, expected);
   }
 
   public void assertFormatter(Formatter impl, Arguments args, String json, String expected) throws CodeException {
     assertEquals(format(impl, args, json), expected);
+  }
+
+  public void assertFormatterRaw(Formatter impl, String json, JsonNode expected) throws CodeException {
+    assertFormatterRaw(impl, EMPTY_ARGUMENTS, json, expected);
+  }
+
+  public void assertFormatterRaw(Formatter impl, Arguments args, String json, JsonNode expected) throws CodeException {
+    assertEquals(formatRaw(impl, args, json), expected);
   }
 
   public void assertInvalidArgs(Formatter impl, Arguments args) {

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -55,6 +55,7 @@ import com.squarespace.template.plugins.CoreFormatters.HtmlFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlTagFormatter;
 import com.squarespace.template.plugins.CoreFormatters.JsonFormatter;
 import com.squarespace.template.plugins.CoreFormatters.JsonPrettyFormatter;
+import com.squarespace.template.plugins.CoreFormatters.KeyByFormatter;
 import com.squarespace.template.plugins.CoreFormatters.LookupFormatter;
 import com.squarespace.template.plugins.CoreFormatters.ModFormatter;
 import com.squarespace.template.plugins.CoreFormatters.OutputFormatter;
@@ -84,6 +85,7 @@ public class CoreFormattersTest extends UnitTestBase {
   private static final Formatter HTMLTAG = new HtmlTagFormatter();
   private static final Formatter JSON = new JsonFormatter();
   private static final Formatter JSON_PRETTY = new JsonPrettyFormatter();
+  private static final Formatter KEY_BY = new KeyByFormatter();
   private static final Formatter OUTPUT = new OutputFormatter();
   private static final Formatter LOOKUP = new LookupFormatter();
   private static final Formatter MOD = new ModFormatter();
@@ -506,6 +508,33 @@ public class CoreFormattersTest extends UnitTestBase {
 
     runner.exec("f-json-%N.html");
     runner.exec("f-json-pretty-%N.html");
+  }
+
+  @Test
+  public void testKeyBy() throws CodeException {
+    CodeMaker mk = maker();
+
+    Arguments args = mk.args(" id");
+    assertFormatterRaw(KEY_BY, args, "{}", JsonUtils.decode("{}"));
+
+    args = mk.args(" id");
+    assertFormatterRaw(KEY_BY, args, "[]", JsonUtils.decode("{}"));
+
+    args = mk.args(" id");
+    assertFormatterRaw(
+        KEY_BY,
+        args,
+        "[{ \"id\": 1 }, { \"id\": 2 }, { \"invalid\": 4 }]",
+        JsonUtils.decode("{\"1\":{\"id\":1},\"2\":{\"id\":2}}")
+    );
+
+    args = mk.args(" test.0.deep");
+    assertFormatterRaw(
+        KEY_BY,
+        args,
+        "[{ \"test\": [{ \"deep\": 1 }] }, { \"test\": [{ \"deep\": 2 }] }]",
+        JsonUtils.decode("{\"1\":{\"test\":[{\"deep\":1}]},\"2\":{\"test\":[{\"deep\":2}]}}")
+    );
   }
 
   @Test

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -535,6 +535,8 @@ public class CoreFormattersTest extends UnitTestBase {
         "[{ \"test\": [{ \"deep\": 1 }] }, { \"test\": [{ \"deep\": 2 }] }]",
         JsonUtils.decode("{\"1\":{\"test\":[{\"deep\":1}]},\"2\":{\"test\":[{\"deep\":2}]}}")
     );
+
+    runner.exec("f-key-by-%N.html");
   }
 
   @Test

--- a/core/src/test/resources/com/squarespace/template/plugins/f-key-by-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-key-by-1.html
@@ -1,0 +1,25 @@
+:JSON
+{
+    "people": [
+        {
+            "name": "Bob",
+            "emails": {
+                "primary": "bob@example.com",
+                "secondary": "bob2@example.com"
+            }
+        },
+        {
+            "name": "Joe",
+            "emails": {
+                "primary": "joe@example.com",
+                "secondary": "joe2@example.com"
+            }
+        }
+    ]
+}
+
+:TEMPLATE
+{people|key-by name|prop Bob.emails.primary}
+
+:OUTPUT
+bob@example.com


### PR DESCRIPTION
### [DIG-641](https://squarespace.atlassian.net/browse/DIG-641)

### Related PR
https://github.com/Squarespace/template-engine/pull/21

### Description
- Added new key-by formatter which takes a given array node and tries to map each of the objects inside by the value at the given key path. This can be stored in a var and used in conjunction with the get or prop formatters to allow the user to easily access objects by some key (e.g. id) from anywhere in the template
- Added new method, getNodeAtPath, to GeneralUtils with code taken from the prop formatter because the same logic is used by key-by
   - Updated the prop formatter to use the new util
- Added tests for new key-by formatter and getNodeAtPath