### PR TITLE
[COM-28756]: update product-scarcity to hide when attributes exists

### DIFF
--- a/core/src/main/resources/com/squarespace/template/plugins/platform/product-scarcity.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/product-scarcity.html
@@ -1,11 +1,5 @@
 {.repeated section scarcityTemplateViews}
-  {.equal? @index 1}
-    <div class="product-scarcity"{.if scarcityShownByDefault}{.or} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
-      {scarcityText|message qtyInStock:qtyInStock|htmltag}
-    </div>
-  {.or}
-    <div class="product-scarcity"{.if attributes} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
-      {scarcityText|message qtyInStock:qtyInStock|htmltag}
-    </div>
-  {.end}
+  <div class="product-scarcity"{.if attributes} data-variant-attributes="{attributes|json|htmltag}" hidden{.end}>
+    {scarcityText|message qtyInStock:qtyInStock|htmltag}
+  </div>
 {.end}

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-hidden.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-hidden.html
@@ -27,13 +27,11 @@
 {item|product-scarcity}
 
 :OUTPUT
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
-      Only 3 left!
-    </div>
-  
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+    Only 3 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
-      Only 7 left!
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
+    Only 7 left!
+  </div>
 

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown-and-variants.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown-and-variants.html
@@ -29,18 +29,14 @@
 {item|product-scarcity}
 
 :OUTPUT
-    <div class="product-scarcity">
-      Only 3 left!
-    </div>
-  
+  <div class="product-scarcity">
+    Only 3 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
-      Only 10 left!
-    </div>
-  
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Blue&quot;}" hidden>
+    Only 10 left!
+  </div>
 
-  
-    <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Green&quot;}" hidden>
-      Only 2 left!
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Green&quot;}" hidden>
+    Only 2 left!
+  </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown-escape-html.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown-escape-html.html
@@ -22,6 +22,6 @@
 {item|product-scarcity}
 
 :OUTPUT
-<div class="product-scarcity">
-      Only 3 left! &lt;img src=x&gt;
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+    Only 3 left! &lt;img src=x&gt;
+  </div>

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-scarcity-default-shown.html
@@ -22,6 +22,6 @@
 {item|product-scarcity}
 
 :OUTPUT
-<div class="product-scarcity">
-      Only 3 left!
-    </div>
+  <div class="product-scarcity" data-variant-attributes="{&quot;Color&quot;:&quot;Red&quot;}" hidden>
+    Only 3 left!
+  </div>


### PR DESCRIPTION
When attributes exists, we want to hide `product-scarcity` When on the PLP there's a edge case where product-status limit is for example, 10. When a product has multiple variants, the summation of variants (TOTAL_STOCK) could be above 10. However, each variant could be below 10. In this case, we're actually showing TOTAL_STOCK as one of the variants.. which is not right. Since for total stock scarcity, `attributes` is not part of the object, we can assume that scarcity with attributes are a variant while without are total stock. 