### PR TITLE
[COM-32536]: Variant pricing bug fixes

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/platform/CommerceFormatters.java
@@ -493,14 +493,14 @@ public class CommerceFormatters implements FormatterRegistry {
       JsonNode pricingOptions = CommerceUtils.getPricingOptionsAmongLowestVariant(node);
 
       if (pricingOptions != null && pricingOptions.size() > 0) {
-        if (CommerceUtils.hasVariants(node)) {
+        if (CommerceUtils.hasVariedPrices(node)) {
           // This will return either salePriceMoney or priceMoney depending on whether the onSale is true or false.
           // That's because this block here is the from {price} so the from price needs to be the lowest possible price
           // taking into if a variant is onSale.
           JsonNode subscriptionFromPricingNode = CommerceUtils.getSubscriptionMoneyFromFirstPricingOptions(pricingOptions);
 
           subscriptionResults.put("fromText", StringUtils.defaultIfEmpty(
-                  ctx.resolve(Constants.PRODUCT_PRICE_FROM_TEXT_KEY).asText(), "from {price}"));
+                  ctx.resolve(Constants.PRODUCT_PRICE_FROM_TEXT_KEY).asText(), "from {fromPrice}"));
           subscriptionResults.put("formattedFromPrice", CommerceUtils.getMoneyString(subscriptionFromPricingNode, ctx));
         }
 

--- a/core/src/main/resources/com/squarespace/template/plugins/platform/subscription-price.html
+++ b/core/src/main/resources/com/squarespace/template/plugins/platform/subscription-price.html
@@ -7,7 +7,7 @@
   normal-price if both from-price and sale-price doesn't exists.
 ##}
 <div class="subscription-price">
-{.if formattedFromPrice}{fromText|message price:formattedFromPrice}
+{.if formattedFromPrice}{fromText|message fromPrice:formattedFromPrice}
 {.or}{.if formattedSubscriptionSalePrice}<span class="visually-hidden v6-visually-hidden">{.if @salePriceText}{@salePriceText|htmltag}{.or}Sale Price:{.end}</span>{formattedSubscriptionSalePriceText|message price:formattedSubscriptionSalePrice}{.space}<span class="visually-hidden v6-visually-hidden">{.if @originalPriceText}{@originalPriceText|htmltag}{.or}Original Price:{.end}</span><span class="original-price">{formattedNormalSubscriptionPriceText|message price:formattedNormalSubscriptionPrice}</span>
 {.or}{.if formattedNormalSubscriptionPrice}{formattedNormalSubscriptionPriceText|message price:formattedNormalSubscriptionPrice}{.end}{.end}{.end}
 </div>

--- a/core/src/test/java/com/squarespace/template/plugins/platform/CommerceFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/CommerceFormattersTest.java
@@ -248,7 +248,7 @@ public class CommerceFormattersTest extends PlatformUnitTestBase {
          "f-subscription-price-on-sale-variants-pricing-options.html",
          "f-subscription-price-one-on-sale-pricing-option.html",
          "f-subscription-price-one-pricing-option.html",
-//         "f-subscription-price-variants-with-same-pricing.html",
+         "f-subscription-price-variants-with-same-pricing.html",
          "f-subscription-price-no-pricing-options.html"
     );
   }

--- a/core/src/test/java/com/squarespace/template/plugins/platform/CommerceFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/platform/CommerceFormattersTest.java
@@ -248,6 +248,7 @@ public class CommerceFormattersTest extends PlatformUnitTestBase {
          "f-subscription-price-on-sale-variants-pricing-options.html",
          "f-subscription-price-one-on-sale-pricing-option.html",
          "f-subscription-price-one-pricing-option.html",
+//         "f-subscription-price-variants-with-same-pricing.html",
          "f-subscription-price-no-pricing-options.html"
     );
   }

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-subscription-price-multiple-variants-and-multiple-pricing-options.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-subscription-price-multiple-variants-and-multiple-pricing-options.html
@@ -3,6 +3,7 @@
   "structuredContent": {
     "productType": 1,
     "variants": [{
+      "price": 1000,
       "priceMoney": {
         "value": "10"
       },
@@ -55,6 +56,7 @@
       }]
     },
     {
+      "price": 2000,
       "priceMoney": {
         "value": "20"
       },
@@ -84,6 +86,7 @@
       }]
     },
     {
+      "price": 3000,
       "priceMoney": {
         "value": "30"
       },

--- a/core/src/test/resources/com/squarespace/template/plugins/platform/f-subscription-price-variants-with-same-pricing.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/platform/f-subscription-price-variants-with-same-pricing.html
@@ -1,0 +1,186 @@
+:JSON
+{
+  "structuredContent": {
+    "productType": 1,
+    "variants" : [ {
+      "attributes" : {
+        "Color" : "Navy"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Navy"
+      } ],
+      "id" : "2c15e571-96a3-416d-bcbf-b586fb6d86a5",
+      "sku" : "SQ4623793",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    }, {
+      "attributes" : {
+        "Color" : "Red"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Red"
+      } ],
+      "id" : "30303da6-ae10-4cc4-8639-ebdf1e86e3b8",
+      "sku" : "SQ0235523",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    }, {
+      "attributes" : {
+        "Color" : "Green"
+      },
+      "optionValues" : [ {
+        "optionName" : "Color",
+        "value" : "Green"
+      } ],
+      "id" : "5ac0518a-38f3-4910-ae11-1e90a87c46e5",
+      "sku" : "SQ8531651",
+      "price" : 2000,
+      "salePrice" : 0,
+      "priceMoney" : {
+        "currency" : "USD",
+        "value" : "20.00"
+      },
+      "salePriceMoney" : {
+        "currency" : "USD",
+        "value" : "0.00"
+      },
+      "onSale" : false,
+      "unlimited" : false,
+      "qtyInStock" : 1,
+      "width" : 0.0,
+      "height" : 0.0,
+      "weight" : 0.0,
+      "imageIds" : [ ],
+      "images" : [ ],
+      "pricingOptions" : [ {
+        "price" : 1800,
+        "salePrice" : 0,
+        "percentageDiscount" : 0.1,
+        "priceMoney" : {
+          "currency" : "USD",
+          "value" : "18.00"
+        },
+        "salePriceMoney" : {
+          "currency" : "USD",
+          "value" : "0.00"
+        },
+        "onSale" : false,
+        "productSubscriptionOptionId" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+        "subscriptionPlan" : {
+          "billingPeriod" : {
+            "value" : 1,
+            "unit" : "WEEK"
+          },
+          "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+          "numBillingCycles" : 5
+        }
+      } ],
+      "len" : 0.0
+    } ],
+    "variantOptionOrdering" : [ "Color" ],
+    "isSubscribable" : false,
+    "fulfilledExternally" : false,
+    "productSubscriptionOptions" : [ {
+      "id" : "f6949b20-8d71-447a-a5ee-8c07132e70b4",
+      "percentageDiscount" : 0.1,
+      "subscriptionPlan" : {
+        "billingPeriod" : {
+          "value" : 1,
+          "unit" : "WEEK"
+        },
+        "planVersionId" : "30066d47-c460-4ee2-b53e-3d4ec2c008a7",
+        "numBillingCycles" : 5
+      }
+    }]
+  }
+}
+
+:TEMPLATE
+{@|subscription-price}
+
+:OUTPUT
+<div class="subscription-price">
+<span class="sqs-money-native">18.00</span>
+</div>


### PR DESCRIPTION
This PR fixes one case where instead of just checking if product has variants to calculate the `from {price}` we need to calculate if prices actually differ in between variants. this is because I missed the case where there could be multiple variants but all with the same price. In this case, we would show the price and not the `from {price}` 