### PR TITLE
Add line-breaks formatter and test cases.

### DIFF
--- a/core/src/main/java/com/squarespace/template/Patterns.java
+++ b/core/src/main/java/com/squarespace/template/Patterns.java
@@ -53,6 +53,7 @@ public class Patterns {
   public static final char POUND_CHAR = '#';
 
   public static final Pattern ONESPACE = Pattern.compile("\\s");
+  public static final Pattern ONENEWLINE = Pattern.compile("\n");
   public static final Pattern WHITESPACE_RE = Pattern.compile("\\s+");
   public static final Pattern WHITESPACE_NBSP = Pattern.compile("[\\s\u200b\u00a0]+");
 

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -83,9 +83,10 @@ public class CoreFormatters implements FormatterRegistry {
     table.add(new JsonFormatter());
     table.add(new JsonPrettyFormatter());
     table.add(new KeyByFormatter());
-    table.add(new OutputFormatter());
+    table.add(new LineBreaksFormatter());
     table.add(new LookupFormatter());
     table.add(new ModFormatter());
+    table.add(new OutputFormatter());
     table.add(new PluralizeFormatter());
     table.add(new PropFormatter());
     table.add(new RawFormatter());
@@ -580,6 +581,25 @@ public class CoreFormatters implements FormatterRegistry {
     }
   }
 
+
+  /**
+   * LINE-BREAKS
+   */
+  public static class LineBreaksFormatter extends BaseFormatter {
+
+    public LineBreaksFormatter() {
+      super("line-breaks", false);
+    }
+
+    @Override
+    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
+      Variable var = variables.first();
+      String value = var.node().asText();
+      String replaced = Patterns.ONENEWLINE.matcher(value).replaceAll("<br/>");
+      var.set(replaced);
+    }
+
+  }
 
   /**
    * OUTPUT

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -56,6 +56,7 @@ import com.squarespace.template.plugins.CoreFormatters.HtmlTagFormatter;
 import com.squarespace.template.plugins.CoreFormatters.JsonFormatter;
 import com.squarespace.template.plugins.CoreFormatters.JsonPrettyFormatter;
 import com.squarespace.template.plugins.CoreFormatters.KeyByFormatter;
+import com.squarespace.template.plugins.CoreFormatters.LineBreaksFormatter;
 import com.squarespace.template.plugins.CoreFormatters.LookupFormatter;
 import com.squarespace.template.plugins.CoreFormatters.ModFormatter;
 import com.squarespace.template.plugins.CoreFormatters.OutputFormatter;
@@ -86,6 +87,7 @@ public class CoreFormattersTest extends UnitTestBase {
   private static final Formatter JSON = new JsonFormatter();
   private static final Formatter JSON_PRETTY = new JsonPrettyFormatter();
   private static final Formatter KEY_BY = new KeyByFormatter();
+  private static final Formatter LINE_BREAKS = new LineBreaksFormatter();
   private static final Formatter OUTPUT = new OutputFormatter();
   private static final Formatter LOOKUP = new LookupFormatter();
   private static final Formatter MOD = new ModFormatter();
@@ -540,6 +542,15 @@ public class CoreFormattersTest extends UnitTestBase {
     );
 
     runner.exec("f-key-by-%N.html");
+  }
+
+  @Test
+  public void testLineBreaks() throws CodeException {
+    runner.exec("f-line-breaks-%N.html");
+
+    assertFormatter(LINE_BREAKS, "\"\"", "");
+    assertFormatter(LINE_BREAKS, "\"  \\n  \"", "  <br/>  ");
+    assertFormatter(LINE_BREAKS, "\"A\\nB\\n\\n\\nC\\nD\"", "A<br/>B<br/><br/><br/>C<br/>D");
   }
 
   @Test

--- a/core/src/test/resources/com/squarespace/template/plugins/f-line-breaks-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-line-breaks-1.html
@@ -1,0 +1,26 @@
+:JSON
+{
+  "quotes": [
+    "|     \n     |",
+    "",
+    "\"abc\"",
+    "\"A\nB\nC\"",
+    "\"\nLong\n\nquote\n\nwith\n\nseveral\n\n\nline\n\nbreaks\n\""
+  ]
+}
+
+:TEMPLATE
+{.repeated section quotes}
+{@|line-breaks}
+{.end}
+
+:OUTPUT
+|     <br/>     |
+
+
+
+"abc"
+
+"A<br/>B<br/>C"
+
+"<br/>Long<br/><br/>quote<br/><br/>with<br/><br/>several<br/><br/><br/>line<br/><br/>breaks<br/>"


### PR DESCRIPTION
Proposal from Joe Wanko:

JSON-T Formatter Spec: `line-breaks`
Arguments: None - operates on the input string directly
Behavior: Converts newline characters ("\n") to HTML line break tags (`<br/>`).

Rationale: This formatter addresses the HTML whitespace collapsing issue where newlines in text content get compressed into single spaces. Converting \n to <br/> ensures line breaks render correctly in HTML.

Edge Cases: Multiple consecutive newlines: Each "\n" becomes a `<br/>` (e.g., "\n\n" → `<br/><br/>`)
Empty string: Returns empty string
No newlines: Returns string unchanged

```
Input: "Line 1\nLine 2\nLine 3"
Output: "Line 1<br/>Line 2<br/>Line 3"
```

Usage Example
```
{quote | line-breaks}
```
