### PR TITLE
Added find-first and find-last formatters with corresponding tests

### DIFF
--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -74,6 +74,8 @@ public class CoreFormatters implements FormatterRegistry {
     table.add(new EncodeSpaceFormatter());
     table.add(new EncodeUriFormatter());
     table.add(new EncodeUriComponentFormatter());
+    table.add(new FindFirstFormatter());
+    table.add(new FindLastFormatter());
     table.add(new FormatFormatter());
     table.add(new GetFormatter());
     table.add(new HtmlFormatter());
@@ -316,6 +318,110 @@ public class CoreFormatters implements FormatterRegistry {
       Variable var = variables.first();
       String value = var.node().asText();
       var.set(EncodeUtils.encodeURIComponent(value));
+    }
+
+  }
+
+  /**
+   * FIND-FIRST - Returns the first element of an array.
+   *
+   * Forms:
+   *   {array|find-first}              first element
+   *   {array|find-first path}         first element where element.path is truthy
+   *   {array|find-first lookup path}  array is treated as a list of keys; each key is
+   *                                   looked up in the `lookup` object (resolved against
+   *                                   the context) and the first key whose looked-up
+   *                                   value has a truthy value at `path` is returned.
+   *
+   * Returns a missing node when the input is not an array, the array is empty,
+   * or no element matches.
+   */
+  public static class FindFirstFormatter extends BaseFormatter {
+
+    public FindFirstFormatter() {
+      super("find-first", false);
+    }
+
+    @Override
+    public void validateArgs(Arguments args) throws ArgumentsException {
+      args.between(0, 2);
+    }
+
+    @Override
+    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
+      Variable var = variables.first();
+      JsonNode node = var.node();
+      if (!node.isArray() || node.size() == 0) {
+        var.set(Constants.MISSING_NODE);
+        return;
+      }
+      if (args.count() == 0) {
+        var.set(node.get(0));
+        return;
+      }
+      boolean hasLookup = args.count() == 2;
+      JsonNode lookup = hasLookup ? ctx.resolve(splitVariable(args.first())) : null;
+      Object[] path = splitVariable(args.get(hasLookup ? 1 : 0));
+      for (JsonNode element : node) {
+        JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
+        if (isTruthy(getNodeAtPath(candidate, path))) {
+          var.set(element);
+          return;
+        }
+      }
+      var.set(Constants.MISSING_NODE);
+    }
+}
+
+  /**
+   * FIND-LAST - Returns the last element of an array.
+   *
+   * Forms:
+   *   {array|find-last}              last element
+   *   {array|find-last path}         last element where element.path is truthy
+   *   {array|find-last lookup path}  array is treated as a list of keys; each key is
+   *                                  looked up in the `lookup` object (resolved against
+   *                                  the context) and the last key whose looked-up
+   *                                  value has a truthy value at `path` is returned.
+   *
+   * Returns a missing node when the input is not an array, the array is empty,
+   * or no element matches.
+   */
+  public static class FindLastFormatter extends BaseFormatter {
+
+    public FindLastFormatter() {
+      super("find-last", false);
+    }
+
+    @Override
+    public void validateArgs(Arguments args) throws ArgumentsException {
+      args.between(0, 2);
+    }
+
+    @Override
+    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
+      Variable var = variables.first();
+      JsonNode node = var.node();
+      if (!node.isArray() || node.size() == 0) {
+        var.set(Constants.MISSING_NODE);
+        return;
+      }
+      if (args.count() == 0) {
+        var.set(node.get(node.size() - 1));
+        return;
+      }
+      boolean hasLookup = args.count() == 2;
+      JsonNode lookup = hasLookup ? ctx.resolve(splitVariable(args.first())) : null;
+      Object[] path = splitVariable(args.get(hasLookup ? 1 : 0));
+      for (int i = node.size() - 1; i >= 0; i--) {
+        JsonNode element = node.get(i);
+        JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
+        if (isTruthy(getNodeAtPath(candidate, path))) {
+          var.set(element);
+          return;
+        }
+      }
+      var.set(Constants.MISSING_NODE);
     }
 
   }

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -78,6 +78,7 @@ public class CoreFormatters implements FormatterRegistry {
     table.add(new EncodeUriComponentFormatter());
     table.add(new FindFirstFormatter());
     table.add(new FindLastFormatter());
+    table.add(new FindNthFormatter());
     table.add(new FormatFormatter());
     table.add(new GetFormatter());
     table.add(new HtmlFormatter());

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -25,6 +25,8 @@ import static com.squarespace.template.GeneralUtils.isTruthy;
 import static com.squarespace.template.GeneralUtils.jsonPretty;
 import static com.squarespace.template.GeneralUtils.splitVariable;
 import static com.squarespace.template.GeneralUtils.getNodeAtPath;
+import static com.squarespace.template.plugins.FindUtils.findNthValidEntry;
+import static com.squarespace.template.plugins.FindUtils.getLookupAndPath;
 import static com.squarespace.template.plugins.PluginDateUtils.formatDate;
 import static com.squarespace.template.plugins.PluginUtils.escapeScriptTags;
 
@@ -350,28 +352,10 @@ public class CoreFormatters implements FormatterRegistry {
     @Override
     public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
       Variable var = variables.first();
-      JsonNode node = var.node();
-      if (!node.isArray() || node.size() == 0) {
-        var.set(Constants.MISSING_NODE);
-        return;
-      }
-      if (args.count() == 0) {
-        var.set(node.get(0));
-        return;
-      }
-      boolean hasLookup = args.count() == 2;
-      JsonNode lookup = hasLookup ? ctx.resolve(splitVariable(args.first())) : null;
-      Object[] path = splitVariable(args.get(hasLookup ? 1 : 0));
-      for (JsonNode element : node) {
-        JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
-        if (isTruthy(getNodeAtPath(candidate, path))) {
-          var.set(element);
-          return;
-        }
-      }
-      var.set(Constants.MISSING_NODE);
+      FindUtils.LookupAndPath lp = getLookupAndPath(ctx, args.getArgs());
+      var.set(findNthValidEntry(var.node(), lp.path, lp.lookup, 0));
     }
-}
+  }
 
   /**
    * FIND-LAST - Returns the last element of an array.
@@ -401,29 +385,53 @@ public class CoreFormatters implements FormatterRegistry {
     @Override
     public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
       Variable var = variables.first();
+      FindUtils.LookupAndPath lp = getLookupAndPath(ctx, args.getArgs());
+      var.set(findNthValidEntry(var.node(), lp.path, lp.lookup, -1));
+    }
+  }
+
+  /**
+   * FIND-NTH - Returns the nth matching element of an array (0-based; negative counts from end).
+   *
+   * Forms:
+   *   {array|find-nth nth}              finds nth element
+   *   {array|find-nth nth path}         finds nth element where element.path is truthy
+   *   {array|find-nth nth lookup path}  array is treated as a list of keys; each key is
+   *                                     looked up in the `lookup` object (resolved against
+   *                                     the context) and the nth key whose looked-up
+   *                                     value has a truthy value at `path` is returned.
+   *
+   * Returns a missing node when the input is not an array, the array is empty,
+   * nth is not an integer, or no element matches.
+   */
+  public static class FindNthFormatter extends BaseFormatter {
+
+    public FindNthFormatter() {
+      super("find-nth", true);
+    }
+
+    @Override
+    public void validateArgs(Arguments args) throws ArgumentsException {
+      args.between(1, 3);
+    }
+
+    @Override
+    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
+      Variable var = variables.first();
       JsonNode node = var.node();
-      if (!node.isArray() || node.size() == 0) {
+
+      int nth;
+      try{
+        nth = Integer.parseInt(args.first());
+      }catch(NumberFormatException e) {
         var.set(Constants.MISSING_NODE);
         return;
       }
-      if (args.count() == 0) {
-        var.set(node.get(node.size() - 1));
-        return;
-      }
-      boolean hasLookup = args.count() == 2;
-      JsonNode lookup = hasLookup ? ctx.resolve(splitVariable(args.first())) : null;
-      Object[] path = splitVariable(args.get(hasLookup ? 1 : 0));
-      for (int i = node.size() - 1; i >= 0; i--) {
-        JsonNode element = node.get(i);
-        JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
-        if (isTruthy(getNodeAtPath(candidate, path))) {
-          var.set(element);
-          return;
-        }
-      }
-      var.set(Constants.MISSING_NODE);
-    }
+      List<String> argsWithoutNth = args.getArgs().subList(1, args.getArgs().size());
+      FindUtils.LookupAndPath lp = getLookupAndPath(ctx, argsWithoutNth);
 
+      var.set(findNthValidEntry(node, lp.path, lp.lookup, nth));
+    }
   }
 
   /**

--- a/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
+++ b/core/src/main/java/com/squarespace/template/plugins/CoreFormatters.java
@@ -78,7 +78,6 @@ public class CoreFormatters implements FormatterRegistry {
     table.add(new EncodeUriComponentFormatter());
     table.add(new FindFirstFormatter());
     table.add(new FindLastFormatter());
-    table.add(new FindNthFormatter());
     table.add(new FormatFormatter());
     table.add(new GetFormatter());
     table.add(new HtmlFormatter());
@@ -354,7 +353,7 @@ public class CoreFormatters implements FormatterRegistry {
     public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
       Variable var = variables.first();
       FindUtils.LookupAndPath lp = getLookupAndPath(ctx, args.getArgs());
-      var.set(findNthValidEntry(var.node(), lp.path, lp.lookup, 0));
+      var.set(findNthValidEntry(var.node(), lp.path, lp.lookup, 1));
     }
   }
 
@@ -390,51 +389,6 @@ public class CoreFormatters implements FormatterRegistry {
       var.set(findNthValidEntry(var.node(), lp.path, lp.lookup, -1));
     }
   }
-
-  /**
-   * FIND-NTH - Returns the nth matching element of an array (0-based; negative counts from end).
-   *
-   * Forms:
-   *   {array|find-nth nth}              finds nth element
-   *   {array|find-nth nth path}         finds nth element where element.path is truthy
-   *   {array|find-nth nth lookup path}  array is treated as a list of keys; each key is
-   *                                     looked up in the `lookup` object (resolved against
-   *                                     the context) and the nth key whose looked-up
-   *                                     value has a truthy value at `path` is returned.
-   *
-   * Returns a missing node when the input is not an array, the array is empty,
-   * nth is not an integer, or no element matches.
-   */
-  public static class FindNthFormatter extends BaseFormatter {
-
-    public FindNthFormatter() {
-      super("find-nth", true);
-    }
-
-    @Override
-    public void validateArgs(Arguments args) throws ArgumentsException {
-      args.between(1, 3);
-    }
-
-    @Override
-    public void apply(Context ctx, Arguments args, Variables variables) throws CodeExecuteException {
-      Variable var = variables.first();
-      JsonNode node = var.node();
-
-      int nth;
-      try{
-        nth = Integer.parseInt(args.first());
-      }catch(NumberFormatException e) {
-        var.set(Constants.MISSING_NODE);
-        return;
-      }
-      List<String> argsWithoutNth = args.getArgs().subList(1, args.getArgs().size());
-      FindUtils.LookupAndPath lp = getLookupAndPath(ctx, argsWithoutNth);
-
-      var.set(findNthValidEntry(node, lp.path, lp.lookup, nth));
-    }
-  }
-
   /**
    * FORMAT - Substitutes positional arguments in a format string.
    */

--- a/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
+++ b/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
@@ -39,11 +39,15 @@ public class FindUtils {
         }
         ArrayNode validEntries = JsonUtils.createArrayNode();
         boolean hasLookup = lookup != null;
-        for (JsonNode element : items) {
-            JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
-            if (isTruthy(getNodeAtPath(candidate, path))) {
-                validEntries.add(candidate);
+        if(hasLookup || path != null){
+            for (JsonNode element : items) {
+                JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
+                if (isTruthy(getNodeAtPath(candidate, path))) {
+                    validEntries.add(element);
+                }
             }
+        } else {
+            validEntries = (ArrayNode)items;
         }
         int size = validEntries.size();
         if (size == 0) {

--- a/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
+++ b/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
@@ -1,0 +1,58 @@
+package com.squarespace.template.plugins;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.squarespace.template.Constants;
+import com.squarespace.template.Context;
+import com.squarespace.template.JsonUtils;
+
+import java.util.List;
+
+import static com.squarespace.template.GeneralUtils.getNodeAtPath;
+import static com.squarespace.template.GeneralUtils.isTruthy;
+import static com.squarespace.template.GeneralUtils.splitVariable;
+
+public class FindUtils {
+
+    public static class LookupAndPath {
+        public final JsonNode lookup;
+        public final Object[] path;
+
+        LookupAndPath(JsonNode lookup, Object[] path) {
+            this.lookup = lookup;
+            this.path = path;
+        }
+    }
+
+    public static LookupAndPath getLookupAndPath(Context ctx, List<String> args) {
+        int argsCount = args.size();
+        boolean hasLookup = argsCount == 2;
+        boolean hasPath = argsCount >= 1;
+        JsonNode lookup = hasLookup ? ctx.resolve(splitVariable(args.get(0))) : null;
+        Object[] path = hasPath ? splitVariable(args.get(hasLookup ? 1 : 0)) : null;
+        return new LookupAndPath(lookup, path);
+    }
+
+    public static JsonNode findNthValidEntry(JsonNode items, Object[] path, JsonNode lookup, int nth) {
+        if (!items.isArray()) {
+            return Constants.MISSING_NODE;
+        }
+        ArrayNode validEntries = JsonUtils.createArrayNode();
+        boolean hasLookup = lookup != null;
+        for (JsonNode element : items) {
+            JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
+            if (isTruthy(getNodeAtPath(candidate, path))) {
+                validEntries.add(candidate);
+            }
+        }
+        int size = validEntries.size();
+        if (size == 0) {
+            return Constants.MISSING_NODE;
+        }
+        int index = nth < 0 ? size + nth : nth;
+        if (index < 0 || index >= size) {
+            return Constants.MISSING_NODE;
+        }
+        return validEntries.get(index);
+    }
+}

--- a/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
+++ b/core/src/main/java/com/squarespace/template/plugins/FindUtils.java
@@ -1,10 +1,8 @@
 package com.squarespace.template.plugins;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.squarespace.template.Constants;
 import com.squarespace.template.Context;
-import com.squarespace.template.JsonUtils;
 
 import java.util.List;
 
@@ -37,26 +35,29 @@ public class FindUtils {
         if (!items.isArray()) {
             return Constants.MISSING_NODE;
         }
-        ArrayNode validEntries = JsonUtils.createArrayNode();
+
+        boolean forward = nth > 0;
+        int start = forward ? 0 : items.size() - 1;
+        int end = forward ? items.size() : -1;
+        int step = forward ? 1 : -1;
+
+        int count = 0;
         boolean hasLookup = lookup != null;
-        if(hasLookup || path != null){
-            for (JsonNode element : items) {
-                JsonNode candidate = hasLookup ? lookup.path(element.asText()) : element;
+        boolean hasPath = path != null;
+
+        for (int i = start; forward ? (i < end) : (i > end); i += step ) {
+            JsonNode node = items.get(i);
+            if (!hasPath){
+                count += step;
+                if (count == nth) { return node;}
+            } else {
+                JsonNode candidate = hasLookup ? lookup.path(node.asText()) : node;
                 if (isTruthy(getNodeAtPath(candidate, path))) {
-                    validEntries.add(element);
+                    count += step;
+                    if (count == nth) { return node;}
                 }
             }
-        } else {
-            validEntries = (ArrayNode)items;
         }
-        int size = validEntries.size();
-        if (size == 0) {
-            return Constants.MISSING_NODE;
-        }
-        int index = nth < 0 ? size + nth : nth;
-        if (index < 0 || index >= size) {
-            return Constants.MISSING_NODE;
-        }
-        return validEntries.get(index);
+        return Constants.MISSING_NODE;
     }
 }

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -52,6 +52,7 @@ import com.squarespace.template.plugins.CoreFormatters.EncodeUriComponentFormatt
 import com.squarespace.template.plugins.CoreFormatters.EncodeUriFormatter;
 import com.squarespace.template.plugins.CoreFormatters.FindFirstFormatter;
 import com.squarespace.template.plugins.CoreFormatters.FindLastFormatter;
+import com.squarespace.template.plugins.CoreFormatters.FindNthFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlAttrFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlTagFormatter;
@@ -85,6 +86,7 @@ public class CoreFormattersTest extends UnitTestBase {
   private static final Formatter ENCODE_URI_COMPONENT = new EncodeUriComponentFormatter();
   private static final Formatter FIND_FIRST = new FindFirstFormatter();
   private static final Formatter FIND_LAST = new FindLastFormatter();
+  private static final Formatter FIND_NTH = new FindNthFormatter();
   private static final Formatter HTML = new HtmlFormatter();
   private static final Formatter HTMLATTR = new HtmlAttrFormatter();
   private static final Formatter HTMLTAG = new HtmlTagFormatter();
@@ -621,6 +623,53 @@ public class CoreFormattersTest extends UnitTestBase {
     .template("{keys|find-last map enabled}")
     .safeExecution(true)
     .execute();
+    assertContext(ctx, "b");
+  }
+
+  @Test
+  public void testFindNth() throws CodeException {
+    CodeMaker mk = maker();
+
+    // index selection
+    assertFormatter(FIND_NTH, mk.args(" 0"), "[\"a\",\"b\",\"c\"]", "a");
+    assertFormatter(FIND_NTH, mk.args(" 1"), "[\"a\",\"b\",\"c\"]", "b");
+    assertFormatter(FIND_NTH, mk.args(" 2"), "[\"a\",\"b\",\"c\"]", "c");
+
+    // negative index (counts from end)
+    assertFormatter(FIND_NTH, mk.args(" -1"), "[\"a\",\"b\",\"c\"]", "c");
+    assertFormatter(FIND_NTH, mk.args(" -2"), "[\"a\",\"b\",\"c\"]", "b");
+
+    // out of bounds
+    assertFormatter(FIND_NTH, mk.args(" 5"), "[\"a\",\"b\",\"c\"]", "");
+    assertFormatter(FIND_NTH, mk.args(" -4"), "[\"a\",\"b\",\"c\"]", "");
+
+    // edge cases: empty array, non-array, non-integer nth
+    assertFormatter(FIND_NTH, mk.args(" 0"), "[]", "");
+    assertFormatter(FIND_NTH, mk.args(" 0"), "\"not-an-array\"", "");
+    assertFormatter(FIND_NTH, mk.args(" notAnInt"), "[\"a\",\"b\",\"c\"]", "");
+
+    // with path filter
+    assertFormatterRaw(
+        FIND_NTH, mk.args(" 1 enabled"),
+        "[{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]",
+        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
+    );
+    assertFormatter(FIND_NTH, mk.args(" 0 enabled"), "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]", "");
+
+    // with path filter via template
+    Context ctx = compiler().newExecutor()
+        .json("{\"items\": [{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]}")
+        .template("{.var @item items|find-nth 1 enabled}{@item.id}")
+        .safeExecution(true)
+        .execute();
+    assertContext(ctx, "b");
+
+    // with lookup + path filter via template
+    ctx = compiler().newExecutor()
+        .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": true}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": false}}}")
+        .template("{keys|find-nth 1 map enabled}")
+        .safeExecution(true)
+        .execute();
     assertContext(ctx, "b");
   }
 

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -52,7 +52,6 @@ import com.squarespace.template.plugins.CoreFormatters.EncodeUriComponentFormatt
 import com.squarespace.template.plugins.CoreFormatters.EncodeUriFormatter;
 import com.squarespace.template.plugins.CoreFormatters.FindFirstFormatter;
 import com.squarespace.template.plugins.CoreFormatters.FindLastFormatter;
-import com.squarespace.template.plugins.CoreFormatters.FindNthFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlAttrFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlTagFormatter;
@@ -86,7 +85,6 @@ public class CoreFormattersTest extends UnitTestBase {
   private static final Formatter ENCODE_URI_COMPONENT = new EncodeUriComponentFormatter();
   private static final Formatter FIND_FIRST = new FindFirstFormatter();
   private static final Formatter FIND_LAST = new FindLastFormatter();
-  private static final Formatter FIND_NTH = new FindNthFormatter();
   private static final Formatter HTML = new HtmlFormatter();
   private static final Formatter HTMLATTR = new HtmlAttrFormatter();
   private static final Formatter HTMLTAG = new HtmlTagFormatter();
@@ -552,125 +550,12 @@ public class CoreFormattersTest extends UnitTestBase {
 
   @Test
   public void testFindFirst() throws CodeException {
-    CodeMaker mk = maker();
-
-    assertFormatter(FIND_FIRST, "[\"a\",\"b\",\"c\"]", "a");
-    assertFormatter(FIND_FIRST, "[]", "");
-    assertFormatter(FIND_FIRST, "\"not-an-array\"", "");
-    assertFormatterRaw(FIND_FIRST, "[{\"x\":1},{\"x\":2}]", JsonUtils.decode("{\"x\":1}"));
-
-    Arguments args = mk.args(" enabled");
-    assertFormatterRaw(
-        FIND_FIRST,
-        args,
-        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":true}]",
-        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
-    );
-    assertFormatter(
-        FIND_FIRST,
-        args,
-        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]",
-        ""
-    );
-
-    Context ctx = compiler().newExecutor()
-    .json("{\"items\": [{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":true}]}")
-    .template("{.var @firstEnabled items|find-first enabled}{@firstEnabled.id}")
-    .safeExecution(true)
-    .execute();
-    assertContext(ctx, "b");
-
-    ctx = compiler().newExecutor()
-    .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": false}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": true}}}")
-    .template("{keys|find-first map enabled}")
-    .safeExecution(true)
-    .execute();
-    assertContext(ctx, "b");
+    runner.exec("f-find-first-%N.html");
   }
 
   @Test
   public void testFindLast() throws CodeException {
-    CodeMaker mk = maker();
-
-    assertFormatter(FIND_LAST, "[\"a\",\"b\",\"c\"]", "c");
-    assertFormatter(FIND_LAST, "[]", "");
-    assertFormatter(FIND_LAST, "\"not-an-array\"", "");
-    assertFormatterRaw(FIND_LAST, "[{\"x\":1},{\"x\":2}]", JsonUtils.decode("{\"x\":2}"));
-
-    Arguments args = mk.args(" enabled");
-    assertFormatterRaw(
-        FIND_LAST,
-        args,
-        "[{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]",
-        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
-    );
-    assertFormatter(
-        FIND_LAST,
-        args,
-        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]",
-        ""
-    );
-
-    Context ctx = compiler().newExecutor()
-    .json("{\"items\": [{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]}")
-    .template("{.var @lastEnabled items|find-last enabled}{@lastEnabled.id}")
-    .safeExecution(true)
-    .execute();
-    assertContext(ctx, "b");
-
-    ctx = compiler().newExecutor()
-    .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": true}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": false}}}")
-    .template("{keys|find-last map enabled}")
-    .safeExecution(true)
-    .execute();
-    assertContext(ctx, "b");
-  }
-
-  @Test
-  public void testFindNth() throws CodeException {
-    CodeMaker mk = maker();
-
-    // index selection
-    assertFormatter(FIND_NTH, mk.args(" 0"), "[\"a\",\"b\",\"c\"]", "a");
-    assertFormatter(FIND_NTH, mk.args(" 1"), "[\"a\",\"b\",\"c\"]", "b");
-    assertFormatter(FIND_NTH, mk.args(" 2"), "[\"a\",\"b\",\"c\"]", "c");
-
-    // negative index (counts from end)
-    assertFormatter(FIND_NTH, mk.args(" -1"), "[\"a\",\"b\",\"c\"]", "c");
-    assertFormatter(FIND_NTH, mk.args(" -2"), "[\"a\",\"b\",\"c\"]", "b");
-
-    // out of bounds
-    assertFormatter(FIND_NTH, mk.args(" 5"), "[\"a\",\"b\",\"c\"]", "");
-    assertFormatter(FIND_NTH, mk.args(" -4"), "[\"a\",\"b\",\"c\"]", "");
-
-    // edge cases: empty array, non-array, non-integer nth
-    assertFormatter(FIND_NTH, mk.args(" 0"), "[]", "");
-    assertFormatter(FIND_NTH, mk.args(" 0"), "\"not-an-array\"", "");
-    assertFormatter(FIND_NTH, mk.args(" notAnInt"), "[\"a\",\"b\",\"c\"]", "");
-
-    // with path filter
-    assertFormatterRaw(
-        FIND_NTH, mk.args(" 1 enabled"),
-        "[{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]",
-        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
-    );
-    assertFormatter(FIND_NTH, mk.args(" 0 enabled"), "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]", "");
-
-    // with path filter via template
-    Context ctx = compiler().newExecutor()
-        .json("{\"items\": [{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]}")
-        .template("{.var @item items|find-nth 1 enabled}{@item.id}")
-        .safeExecution(true)
-        .execute();
-    assertContext(ctx, "b");
-
-    // with lookup + path filter via template
-    ctx = compiler().newExecutor()
-        .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": true}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": false}}}")
-        .template("{keys|find-nth 1 map enabled}")
-        .safeExecution(true)
-        .execute();
-    assertContext(ctx, "b");
+    runner.exec("f-find-last-%N.html");
   }
 
   @Test

--- a/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
+++ b/core/src/test/java/com/squarespace/template/plugins/CoreFormattersTest.java
@@ -50,6 +50,8 @@ import com.squarespace.template.plugins.CoreFormatters.CycleFormatter;
 import com.squarespace.template.plugins.CoreFormatters.EncodeSpaceFormatter;
 import com.squarespace.template.plugins.CoreFormatters.EncodeUriComponentFormatter;
 import com.squarespace.template.plugins.CoreFormatters.EncodeUriFormatter;
+import com.squarespace.template.plugins.CoreFormatters.FindFirstFormatter;
+import com.squarespace.template.plugins.CoreFormatters.FindLastFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlAttrFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlFormatter;
 import com.squarespace.template.plugins.CoreFormatters.HtmlTagFormatter;
@@ -81,6 +83,8 @@ public class CoreFormattersTest extends UnitTestBase {
   private static final Formatter ENCODE_SPACE = new EncodeSpaceFormatter();
   private static final Formatter ENCODE_URI = new EncodeUriFormatter();
   private static final Formatter ENCODE_URI_COMPONENT = new EncodeUriComponentFormatter();
+  private static final Formatter FIND_FIRST = new FindFirstFormatter();
+  private static final Formatter FIND_LAST = new FindLastFormatter();
   private static final Formatter HTML = new HtmlFormatter();
   private static final Formatter HTMLATTR = new HtmlAttrFormatter();
   private static final Formatter HTMLTAG = new HtmlTagFormatter();
@@ -542,6 +546,82 @@ public class CoreFormattersTest extends UnitTestBase {
     );
 
     runner.exec("f-key-by-%N.html");
+  }
+
+  @Test
+  public void testFindFirst() throws CodeException {
+    CodeMaker mk = maker();
+
+    assertFormatter(FIND_FIRST, "[\"a\",\"b\",\"c\"]", "a");
+    assertFormatter(FIND_FIRST, "[]", "");
+    assertFormatter(FIND_FIRST, "\"not-an-array\"", "");
+    assertFormatterRaw(FIND_FIRST, "[{\"x\":1},{\"x\":2}]", JsonUtils.decode("{\"x\":1}"));
+
+    Arguments args = mk.args(" enabled");
+    assertFormatterRaw(
+        FIND_FIRST,
+        args,
+        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":true}]",
+        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
+    );
+    assertFormatter(
+        FIND_FIRST,
+        args,
+        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]",
+        ""
+    );
+
+    Context ctx = compiler().newExecutor()
+    .json("{\"items\": [{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":true}]}")
+    .template("{.var @firstEnabled items|find-first enabled}{@firstEnabled.id}")
+    .safeExecution(true)
+    .execute();
+    assertContext(ctx, "b");
+
+    ctx = compiler().newExecutor()
+    .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": false}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": true}}}")
+    .template("{keys|find-first map enabled}")
+    .safeExecution(true)
+    .execute();
+    assertContext(ctx, "b");
+  }
+
+  @Test
+  public void testFindLast() throws CodeException {
+    CodeMaker mk = maker();
+
+    assertFormatter(FIND_LAST, "[\"a\",\"b\",\"c\"]", "c");
+    assertFormatter(FIND_LAST, "[]", "");
+    assertFormatter(FIND_LAST, "\"not-an-array\"", "");
+    assertFormatterRaw(FIND_LAST, "[{\"x\":1},{\"x\":2}]", JsonUtils.decode("{\"x\":2}"));
+
+    Arguments args = mk.args(" enabled");
+    assertFormatterRaw(
+        FIND_LAST,
+        args,
+        "[{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]",
+        JsonUtils.decode("{\"id\":\"b\",\"enabled\":true}")
+    );
+    assertFormatter(
+        FIND_LAST,
+        args,
+        "[{\"id\":\"a\",\"enabled\":false},{\"id\":\"b\"}]",
+        ""
+    );
+
+    Context ctx = compiler().newExecutor()
+    .json("{\"items\": [{\"id\":\"a\",\"enabled\":true},{\"id\":\"b\",\"enabled\":true},{\"id\":\"c\",\"enabled\":false}]}")
+    .template("{.var @lastEnabled items|find-last enabled}{@lastEnabled.id}")
+    .safeExecution(true)
+    .execute();
+    assertContext(ctx, "b");
+
+    ctx = compiler().newExecutor()
+    .json("{\"keys\": [\"a\", \"b\", \"c\"], \"map\": {\"a\": {\"enabled\": true}, \"b\": {\"enabled\": true}, \"c\": {\"enabled\": false}}}")
+    .template("{keys|find-last map enabled}")
+    .safeExecution(true)
+    .execute();
+    assertContext(ctx, "b");
   }
 
   @Test

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-first-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-first-1.html
@@ -1,0 +1,18 @@
+:JSON
+{
+  "items": [
+    { "id": "a", "enabled": false },
+    { "id": "b", "enabled": true },
+    { "id": "c", "enabled": true }
+  ]
+}
+
+:TEMPLATE
+{.var @first items|find-first}{@first.id}
+{.var @first items|find-first enabled}{@first.id}
+{.var @first items|find-first disabled}{@first.id} {# Note: "disabled" is not a valid path, so it should return nothing #}
+
+:OUTPUT
+a
+b
+

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-first-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-first-2.html
@@ -1,0 +1,15 @@
+:JSON
+{
+  "keys": ["a", "b", "c"],
+  "map": {
+    "a": { "enabled": false },
+    "b": { "enabled": true },
+    "c": { "enabled": true }
+  }
+}
+
+:TEMPLATE
+{keys|find-first map enabled}
+
+:OUTPUT
+b

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-first-3.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-first-3.html
@@ -1,0 +1,22 @@
+:JSON
+{
+  "strings": ["a", "b", "c"],
+  "empty": [],
+  "notArray": "not-an-array",
+  "objects": [{ "x": 1 }, { "x": 2 }],
+  "noMatch": [{ "id": "a", "enabled": false }, { "id": "b" }]
+}
+
+:TEMPLATE
+{.var @r strings|find-first}{@r}
+{.var @r empty|find-first}-{@r}
+{.var @r notArray|find-first}-{@r}
+{.var @r objects|find-first}{@r.x}
+{.var @r noMatch|find-first enabled}-{@r}
+
+:OUTPUT
+a
+-
+-
+1
+-

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-last-1.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-last-1.html
@@ -1,0 +1,14 @@
+:JSON
+{
+  "items": [
+    { "id": "a", "enabled": true },
+    { "id": "b", "enabled": true },
+    { "id": "c", "enabled": false }
+  ]
+}
+
+:TEMPLATE
+{.var @last items|find-last enabled}{@last.id}
+
+:OUTPUT
+b

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-last-2.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-last-2.html
@@ -1,0 +1,15 @@
+:JSON
+{
+  "keys": ["a", "b", "c"],
+  "map": {
+    "a": { "enabled": true },
+    "b": { "enabled": true },
+    "c": { "enabled": false }
+  }
+}
+
+:TEMPLATE
+{keys|find-last map enabled}
+
+:OUTPUT
+b

--- a/core/src/test/resources/com/squarespace/template/plugins/f-find-last-3.html
+++ b/core/src/test/resources/com/squarespace/template/plugins/f-find-last-3.html
@@ -1,0 +1,22 @@
+:JSON
+{
+  "strings": ["a", "b", "c"],
+  "empty": [],
+  "notArray": "not-an-array",
+  "objects": [{ "x": 1 }, { "x": 2 }],
+  "noMatch": [{ "id": "a", "enabled": false }, { "id": "b" }]
+}
+
+:TEMPLATE
+{.var @r strings|find-last}{@r}
+{.var @r empty|find-last}-{@r}
+{.var @r notArray|find-last}-{@r}
+{.var @r objects|find-last}{@r.x}
+{.var @r noMatch|find-last enabled}-{@r}
+
+:OUTPUT
+c
+-
+-
+2
+-


### PR DESCRIPTION
This PR adds two new formatters to the compiler, find-first and find-last that allow you to find the first/last element that returns a truthy given a path and lookup. See this [ticket](https://squarespace.atlassian.net/browse/WEB-17161) for the reason we need these new formatters. 

### Syntax

```syntax
find-last/first
find-last/first|PATH
find-last/first|LOOKUP PATH
```

### Arguments
  - <code class="def">PATH</code> *(optional)*
    - Dot-separated path within each element. Returns the last/first element where the value at this path is truthy.
  - <code class="def">LOOKUP</code> *(optional, used with PATH)*
    - Context path resolving to an object. The array is treated as a list of keys; each key is looked up in this object and the last/first key whose looked-up value has a truthy value at `PATH` is returned.


### Examples

#### Return the last element unconditionally:

**JSON**
```json
{
  "items": ["a", "b", "c"]
}
```
**Json-t**
```
{items|find-last}
```
**Output**
```
c
```

#### Return the last element where a nested field is truthy:

**JSON**
```json
{
  "items": [
    { "id": "a", "enabled": true },
    { "id": "b", "enabled": true },
    { "id": "c", "enabled": false }
  ]
}
```
**Json-t**
```
{.var @last items|find-last enabled}{@last.id}
```
**Output**
```
b
```

#### Look up each key in a separate object and return the last key with a truthy value at a path:
**JSON**
```json
{
  "keys": ["a", "b", "c"],
  "map": {
    "a": { "enabled": false },
    "b": { "enabled": true },
    "c": { "enabled": true }
  }
}
```
**Json-t**
```
#pragma example=lookup
{keys|find-first map enabled}
```
**Output**
```
b
```
